### PR TITLE
Improved README with clear instructions for local inference

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -9,4 +9,4 @@ waveform = render(
     "Hey, here is some random stuff, usually something quite long as the shorter the text the less likely the model can cope!",
 )
 print(waveform.shape)
-torchaudio.save("out.opus", waveform[0], 22050)
+torchaudio.save("out.wav", waveform[0], 22050)

--- a/readme.md
+++ b/readme.md
@@ -2,19 +2,42 @@
 
 Small Conversational speech models that can run on device
 
-# Installation
+# Run Locally
 
+Create environment:
 ```sh
-uv pip install -e .
+uv venv --python=3.12
 ```
-
-# Demo
-
-[Try on Gradio](https://huggingface.co/spaces/fluxions/vui-space)
-
+Activate environment:
+```sh
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+```
+Install core dependencies:
+```sh
+uv pip install -e . --link-mode=copy
+```
+(Windows only) Install Triton:
+```sh
+uv pip install triton_windows --link-mode=copy
+```
+(Optional) Install latest PyTorch (CUDA 12.6):
+```sh
+uv pip install --upgrade torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126 --link-mode=copy
+```
+Authenticate with Hugging Face:
+```sh
+huggingface-cli login
+```
+Finally, run the demo:
 ```sh
 python demo.py
-````
+```
+*Before running `demo.py`, you must accept model terms for [Voice Activity Detection](https://huggingface.co/pyannote/voice-activity-detection) and [Segmentation](https://huggingface.co/pyannote/segmentation) on Hugging Face.*
+
+# Live Demo
+[Try on Gradio](https://huggingface.co/spaces/fluxions/vui-space)
+
+
 
 # Models
 
@@ -56,3 +79,4 @@ fluac is a audio tokenizer based on descript-audio-codec which reduces the numbe
   year = {2025}
 }
 ```
+


### PR DESCRIPTION
**Summary**
- The README now gives clear, step-by-step instructions for setting up the environment and running local inference, including Windows-specific notes and Hugging Face login.
- The inference script now saves output as a `.wav` file instead of `.opus`, making playback straightforward on any system.

**Details**
- Added environment creation, dependency installation, and demo run instructions to the README.
- Noted the need to accept model terms on Hugging Face before running the demo.
- Changed the output file in inference.py to .wav for better compatibility.
