### PR TITLE
Run on ARM64: pin an aarch64 flash-attn wheel, fall back to SDPA elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **ARM64 Linux: `ModuleNotFoundError: No module named 'flash_attn'`.** Only an
+  x86_64 wheel was pinned, so the TTS worker crashed on the first decode step on
+  ARM hosts. Two changes:
+  - `pyproject.toml` now pins an **aarch64** flash-attn wheel as well
+    (2.8.3 + cu130 + torch 2.11 + cp312), so Grace-Hopper / Grace-Blackwell
+    servers run the real kernel.
+  - New `vui.flash_compat` provides a pure-PyTorch SDPA implementation of
+    `flash_attn_with_kvcache` (same semantics, CUDA-graph safe) for everywhere
+    the kernel can't run: CPU/macOS, and Jetson parts (Orin sm_87, Thor sm_110)
+    whose compute capability isn't built into the aarch64 wheel — the launch
+    failure is caught once and attention falls back for the rest of the process.
+    Force it anywhere with `VUI_ATTN=torch`.
+
+  `docker/Dockerfile.stream` also stopped requesting the non-existent `[cuda]`
+  extra.
+
 ## [1.0.0] - 2026-05-14
 
 First production release. Vui shifts from a standalone TTS model to a full

--- a/README.md
+++ b/README.md
@@ -119,9 +119,15 @@ brew install ffmpeg                         # macOS
 Then:
 
 ```sh
-uv sync                  # base + flash-attn pre-built wheel on Linux
+uv sync                  # base + flash-attn pre-built wheel on Linux (x86_64 + aarch64)
 uv sync --extra mlx      # add for Apple Silicon
 ```
+
+Pre-built flash-attn wheels are pinned for Linux x86_64 and aarch64, so ARM
+servers (Grace-Hopper, Grace-Blackwell) get the real kernel. Where it can't run
+— Jetson parts, whose compute capability isn't in the wheel, plus CPU/macOS —
+`vui.flash_compat` transparently switches to a pure-PyTorch SDPA kernel: same
+outputs, slower decode. `VUI_ATTN=torch` forces that path anywhere.
 
 Install [Ollama](https://ollama.com), start it, pull a model, then run the streaming server (defaults to `:8080`):
 ```sh
@@ -298,7 +304,7 @@ For long voice prompts (>15s) you need proper multi-segment chunking — `vui.pr
 ## Hardware
 
 Streaming server and `demo.py` both run on either:
-- **NVIDIA GPU + Linux** — ~**12 GB VRAM** for the full stack (TTS + ASR + Ollama LLM, 4090 / H100 tested), drops to **~8 GB** if you switch to a `moonshine.*` (CPU) ASR backend. CUDA 12.x, flash-attn installed.
+- **NVIDIA GPU + Linux** — ~**12 GB VRAM** for the full stack (TTS + ASR + Ollama LLM, 4090 / H100 tested), drops to **~8 GB** if you switch to a `moonshine.*` (CPU) ASR backend. CUDA 12.x, flash-attn installed. ARM64 servers (GH200 / GB200) work too; Jetson parts fall back to the slower PyTorch SDPA attention automatically.
 - **Apple Silicon Mac** — M1/M2/M3/M4, MLX backend (auto-detected, no flash-attn required).
 
 Full breakdown — measured per-component VRAM, ASR latency/VRAM per backend, KV-cache math, and tuning levers — is in [`docs/memory-budget.md`](docs/memory-budget.md).

--- a/docker/Dockerfile.stream
+++ b/docker/Dockerfile.stream
@@ -22,12 +22,14 @@ COPY pyproject.toml ./
 COPY src ./src
 
 # uv installs Python 3.12 + the project + flash-attn pre-built wheel
-# (resolved via [tool.uv.sources] — pip can't do this).
+# (resolved via [tool.uv.sources] — pip can't do this; x86_64 and aarch64 get
+# different pinned wheels). Where the kernel can't run — e.g. Jetson compute
+# capabilities absent from the wheel — vui.flash_compat uses PyTorch SDPA.
 # nvidia-cublas-cu12 + nvidia-cudnn-cu12 ship the CUDA 12 runtime libs that
 # CTranslate2 (faster-whisper) links against — we run on a CUDA 13 base
 # image (for the flash-attn cu130 wheel), so they coexist via LD_LIBRARY_PATH.
 RUN uv venv --python 3.12 /opt/venv \
-    && uv pip install --no-cache ".[cuda]" \
+    && uv pip install --no-cache "." \
     && uv pip install --no-cache nvidia-cublas-cu12 nvidia-cudnn-cu12
 
 ENV LD_LIBRARY_PATH=/opt/venv/lib/python3.12/site-packages/nvidia/cublas/lib:/opt/venv/lib/python3.12/site-packages/nvidia/cudnn/lib:${LD_LIBRARY_PATH}

--- a/docs/memory-budget.md
+++ b/docs/memory-budget.md
@@ -42,6 +42,8 @@ Measured on a running server (`nvidia-smi --query-compute-apps`, Ollama `/api/ps
 
 Backbone arch (from [`readme`](../README.md#vui-nano)): 768 dim, 22 layers, 8 heads → `head_dim = 96`. No GQA — `n_kv_heads = n_heads = 8`.
 
+**Without flash-attn** (Jetson, CPU, or `VUI_ATTN=torch`) [`vui.flash_compat`](../src/vui/flash_compat.py) attends over the *whole* pre-allocated cache each step — masked, so results match, but both cost and the transient attention scores scale with `max_seqlen` rather than with the filled prefix. Cap `max_seq` on the `Engine` there; it buys latency as well as VRAM.
+
 ### ASR worker — measured 0.85 GiB (default)
 
 `distil-small.en` model.bin on disk: 332 MiB.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ dependencies = [
     # Claude task delegation server (always installed — `claude_server.py`
     # imports it at module load).
     "claude-agent-sdk>=0.1.70",
-    # CUDA flash-attn — Linux only. Pre-built wheel via [tool.uv.sources].
+    # CUDA flash-attn — Linux. Pre-built wheels (x86_64 + aarch64) via [tool.uv.sources].
     # Install with `uv` (not pip — pip ignores [tool.uv.sources] and tries to source-build).
-    "flash-attn ; sys_platform == 'linux'",
+    "flash-attn ; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
     # ctranslate2 (faster-whisper) dlopens libcublas.so.12 at import time;
     # torch brings cu13. This supplies the cu12 ABI ctranslate2 needs.
     "nvidia-cublas-cu12 ; sys_platform == 'linux'",
@@ -59,9 +59,18 @@ moonshine = [
 ]
 
 [tool.uv.sources]
-# Pre-built wheel from a community mirror — avoids the (slow + fragile) source
-# build of flash-attn. Pinned to cu130 + torch 2.10 + cp312.
-flash-attn = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux'" }
+# Pre-built wheels from a community mirror — avoids the (slow + fragile) source
+# build of flash-attn. Both are cu130 + cp312.
+#
+# aarch64 (Grace-Hopper / Grace-Blackwell) gets flash-attn 2.8.3 — the only
+# cu130 build published for ARM, and it matches our torch 2.11 pin exactly.
+# Its kernels cover sm_80/90/100/120 with no PTX fallback, so Jetson parts
+# (Orin sm_87, Thor sm_110) import it fine but fail at launch; vui.flash_compat
+# catches that and switches to the PyTorch SDPA path.
+flash-attn = [
+    { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+    { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3%2Bcu130torch2.11-cp312-cp312-linux_aarch64.whl", marker = "sys_platform == 'linux' and platform_machine == 'aarch64'" },
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/vui/flash_compat.py
+++ b/src/vui/flash_compat.py
@@ -1,0 +1,183 @@
+"""flash-attn compatibility shim.
+
+The model needs exactly one entry point from `flash_attn` —
+`flash_attn_with_kvcache` — and there are hosts where it isn't usable:
+
+* CPU / macOS installs, where the package isn't installed at all;
+* Jetson-class ARM64 (Orin sm_87, Thor sm_110), where the published aarch64
+  wheel imports fine but has no kernels for the device (it is built for
+  sm_80/90/100/120 with no PTX fallback) — that surfaces as a launch-time
+  "no kernel image is available for execution on the device".
+
+Server ARM64 (Grace-Hopper sm_90, Grace-Blackwell sm_100) *is* covered by the
+aarch64 wheel pinned in pyproject.toml, and uses the real kernel.
+
+So this module dispatches: real kernel when importable, and a pure-PyTorch SDPA
+implementation with the same semantics otherwise — including a one-way switch
+if the first real call fails on an unsupported architecture. The fallback is
+CUDA-graph safe (no host syncs, no data-dependent shapes), so the engine's
+captured decode graphs work unchanged. It is slower: it attends over the full
+pre-allocated cache length instead of just the filled prefix, so cap `max_seq`
+when running on it.
+
+Set `VUI_ATTN=torch` to force the fallback (used by the equivalence tests).
+"""
+
+import os
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+__all__ = ["HAS_FLASH_ATTN", "flash_attn_with_kvcache"]
+
+
+def _sdpa_attn_with_kvcache(
+    q: Tensor,
+    k_cache: Tensor,
+    v_cache: Tensor,
+    k: Tensor | None = None,
+    v: Tensor | None = None,
+    cache_seqlens: Tensor | int | None = None,
+    cache_batch_idx: Tensor | None = None,
+    causal: bool = False,
+    window_size: tuple[int, int] = (-1, -1),
+    softmax_scale: float | None = None,
+    **unsupported,
+) -> Tensor:
+    """Pure-PyTorch stand-in for `flash_attn.flash_attn_with_kvcache`.
+
+    q: (B, Tq, H, D). k/v: (B, Tq, Hkv, D), appended to the cache in place at
+    `cache_seqlens`. k_cache/v_cache: (Bc, S, Hkv, D). cache_batch_idx maps the
+    B query rows onto arbitrary cache slots. Queries are right-aligned to the
+    end of the key sequence, as in flash-attn: query i attends up to key index
+    `cache_seqlens + Tnew - Tq + i`.
+
+    Returns (B, Tq, H, D) in q's dtype.
+    """
+    if unsupported:
+        # Better to fail loudly than to silently ignore e.g. rotary_cos/softcap.
+        raise NotImplementedError(
+            f"flash_compat: unsupported flash_attn_with_kvcache arguments: "
+            f"{sorted(unsupported)}"
+        )
+
+    B, Tq, H, D = q.shape
+    S, Hkv = k_cache.shape[1], k_cache.shape[2]
+    device = q.device
+
+    if cache_seqlens is None:
+        seqlens = torch.zeros(B, dtype=torch.long, device=device)
+    elif isinstance(cache_seqlens, int):
+        seqlens = torch.full((B,), cache_seqlens, dtype=torch.long, device=device)
+    else:
+        seqlens = cache_seqlens.to(device=device, dtype=torch.long)
+        if seqlens.numel() == 1:
+            seqlens = seqlens.expand(B)
+
+    slots = None if cache_batch_idx is None else cache_batch_idx.to(torch.long)
+
+    # Append the new K/V into the cache, exactly like the fused kernel does.
+    if k is not None:
+        Tnew = k.shape[1]
+        pos = seqlens[:, None] + torch.arange(Tnew, device=device)  # (B, Tnew)
+        rows = (torch.arange(B, device=device) if slots is None else slots)[:, None]
+        k_cache[rows, pos] = k.to(k_cache.dtype)
+        v_cache[rows, pos] = v.to(v_cache.dtype)
+        klen = seqlens + Tnew
+    else:
+        klen = seqlens
+
+    if slots is None:
+        keys, vals = k_cache[:B], v_cache[:B]  # view, no copy
+    else:
+        keys, vals = k_cache.index_select(0, slots), v_cache.index_select(0, slots)
+
+    keys = keys.permute(0, 2, 1, 3).to(q.dtype)  # (B, Hkv, S, D)
+    vals = vals.permute(0, 2, 1, 3).to(q.dtype)
+    if H != Hkv:
+        n_reps = H // Hkv
+        keys = keys[:, :, None].expand(B, Hkv, n_reps, S, D).reshape(B, H, S, D)
+        vals = vals[:, :, None].expand(B, Hkv, n_reps, S, D).reshape(B, H, S, D)
+
+    # Last key index each query may attend to (right-aligned queries).
+    j = torch.arange(S, device=device)
+    j_max = (klen - Tq)[:, None] + torch.arange(Tq, device=device)  # (B, Tq)
+    if causal:
+        allowed = j <= j_max[..., None]  # (B, Tq, S)
+    else:
+        allowed = j < klen[:, None, None]
+    left, right = window_size
+    if left is not None and left >= 0:
+        allowed = allowed & (j >= (j_max[..., None] - left))
+    if not causal and right is not None and right >= 0:
+        allowed = allowed & (j <= (j_max[..., None] + right))
+
+    # An empty key set would make softmax produce NaNs; flash returns zeros.
+    empty = ~allowed.any(dim=-1, keepdim=True)  # (B, Tq, 1)
+    allowed = allowed | (empty & (j == 0))
+
+    out = F.scaled_dot_product_attention(
+        q.transpose(1, 2),  # (B, H, Tq, D)
+        keys,
+        vals,
+        attn_mask=allowed[:, None],  # (B, 1, Tq, S)
+        scale=softmax_scale,
+    )
+    out = out.masked_fill(empty[:, None], 0)  # (B, 1, Tq, 1) broadcasts over H, D
+    return out.transpose(1, 2).contiguous()  # (B, Tq, H, D)
+
+
+def _load_flash_attn():
+    if os.environ.get("VUI_ATTN", "").lower() in ("torch", "sdpa"):
+        return None
+    try:
+        from flash_attn import flash_attn_with_kvcache as _fn
+
+        return _fn
+    except ImportError:
+        return None
+
+
+_flash_fn = _load_flash_attn()
+HAS_FLASH_ATTN = _flash_fn is not None  # False also when VUI_ATTN forces SDPA
+
+# Launch-time failures that mean "this build has no kernels for this GPU" —
+# Jetson Orin (sm_87) / Thor (sm_110) against an sm_80/90/100/120 wheel.
+_ARCH_ERRORS = (
+    "no kernel image is available",
+    "invalid device function",
+)
+
+
+def _fallback_notice(reason: str) -> None:
+    print(
+        f"[vui] {reason} — using the PyTorch SDPA attention fallback. "
+        "Correct but slower; pass max_seq= to cap the KV cache."
+    )
+
+
+_impl = _flash_fn or _sdpa_attn_with_kvcache
+
+if not HAS_FLASH_ATTN:
+    _fallback_notice("flash_attn unavailable on this platform")
+
+
+def flash_attn_with_kvcache(*args, **kwargs):
+    """flash-attn's kernel, degrading to SDPA if this GPU has no kernels for it.
+
+    The switch is one-way and happens on the first failing call — in practice
+    during engine warm-up, before any CUDA graph capture, so the captured
+    graphs stay consistent.
+    """
+    global _impl
+    if _impl is _sdpa_attn_with_kvcache:
+        return _sdpa_attn_with_kvcache(*args, **kwargs)
+    try:
+        return _impl(*args, **kwargs)
+    except RuntimeError as e:
+        if not any(m in str(e).lower() for m in _ARCH_ERRORS):
+            raise
+        _impl = _sdpa_attn_with_kvcache
+        _fallback_notice(f"flash_attn has no kernels for this GPU ({e})")
+        return _sdpa_attn_with_kvcache(*args, **kwargs)

--- a/src/vui/model.py
+++ b/src/vui/model.py
@@ -214,7 +214,7 @@ class MHA(nn.Module):
         If per_sample_freqs=True, freqs_cis is (B, rot_dim, 2) for T=1 decode.
         If cache_batch_idx is provided, maps B query rows to arbitrary KV cache slots.
         """
-        from flash_attn import flash_attn_with_kvcache
+        from vui.flash_compat import flash_attn_with_kvcache
 
         B, T, _ = x.shape
         qkv = self.Wqkv(x)

--- a/tests/test_flash_compat.py
+++ b/tests/test_flash_compat.py
@@ -1,0 +1,372 @@
+"""Equivalence tests for the pure-PyTorch flash-attn fallback.
+
+Runs on CPU — no flash_attn, no GPU needed. Where flash_attn *is* importable
+(Linux x86_64 + CUDA) `test_matches_flash_attn` also checks the fallback
+against the real kernel.
+
+    pytest tests/test_flash_compat.py
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from vui.flash_compat import HAS_FLASH_ATTN, _sdpa_attn_with_kvcache
+
+torch.manual_seed(0)
+
+B, S, H, HKV, D = 3, 16, 8, 2, 32
+
+
+def _cache(dtype=torch.float32, batch=B):
+    return (
+        torch.randn(batch, S, HKV, D, dtype=dtype),
+        torch.randn(batch, S, HKV, D, dtype=dtype),
+    )
+
+
+def _reference(q, keys, vals, klen, causal, window_left=-1):
+    """Dense reference: explicit softmax over the filled prefix only."""
+    Bq, Tq = q.shape[0], q.shape[1]
+    out = torch.zeros_like(q)
+    n_reps = q.shape[2] // keys.shape[2]
+    for b in range(Bq):
+        n = int(klen[b])
+        for t in range(Tq):
+            j_max = n - Tq + t if causal else n - 1
+            lo = 0 if window_left < 0 else max(0, (n - Tq + t) - window_left)
+            idx = list(range(lo, j_max + 1))
+            if not idx:
+                continue
+            k = keys[b, idx].repeat_interleave(n_reps, dim=1)  # (n_sel, H, D)
+            v = vals[b, idx].repeat_interleave(n_reps, dim=1)
+            scores = torch.einsum("hd,nhd->hn", q[b, t], k) / math.sqrt(D)
+            out[b, t] = torch.einsum("hn,nhd->hd", scores.softmax(-1), v)
+    return out
+
+
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("Tq", [1, 4])
+def test_matches_dense_reference(causal: bool, Tq: int):
+    """Cache append + masking + GQA == dense attention over the filled prefix."""
+    k_cache, v_cache = _cache()
+    q = torch.randn(B, Tq, H, D)
+    k, v = torch.randn(B, Tq, HKV, D), torch.randn(B, Tq, HKV, D)
+    seqlens = torch.tensor([0, 5, 9], dtype=torch.int32)
+
+    expected_k = k_cache.clone()
+    expected_v = v_cache.clone()
+    for b in range(B):
+        expected_k[b, seqlens[b] : seqlens[b] + Tq] = k[b]
+        expected_v[b, seqlens[b] : seqlens[b] + Tq] = v[b]
+
+    out = _sdpa_attn_with_kvcache(
+        q, k_cache, v_cache, k=k, v=v, cache_seqlens=seqlens, causal=causal
+    )
+
+    # K/V were appended in place at cache_seqlens.
+    torch.testing.assert_close(k_cache, expected_k)
+    torch.testing.assert_close(v_cache, expected_v)
+
+    ref = _reference(q, expected_k, expected_v, seqlens + Tq, causal)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_sliding_window():
+    k_cache, v_cache = _cache()
+    q = torch.randn(B, 1, H, D)
+    k, v = torch.randn(B, 1, HKV, D), torch.randn(B, 1, HKV, D)
+    seqlens = torch.tensor([2, 7, 11], dtype=torch.int32)
+    w = 3
+
+    out = _sdpa_attn_with_kvcache(
+        q,
+        k_cache,
+        v_cache,
+        k=k,
+        v=v,
+        cache_seqlens=seqlens,
+        causal=True,
+        window_size=(w, 0),
+    )
+    ref = _reference(q, k_cache, v_cache, seqlens + 1, causal=True, window_left=w)
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_cache_batch_idx():
+    """Query rows read/write arbitrary cache slots, and only those slots."""
+    n_slots = 5
+    k_cache, v_cache = _cache(batch=n_slots)
+    before_k, before_v = k_cache.clone(), v_cache.clone()
+    slots = torch.tensor([4, 0, 2], dtype=torch.int32)
+    seqlens_all = torch.tensor([3, 0, 6, 0, 1], dtype=torch.int32)
+    q = torch.randn(B, 1, H, D)
+    k, v = torch.randn(B, 1, HKV, D), torch.randn(B, 1, HKV, D)
+
+    out = _sdpa_attn_with_kvcache(
+        q,
+        k_cache,
+        v_cache,
+        k=k,
+        v=v,
+        cache_seqlens=seqlens_all[slots.long()],
+        cache_batch_idx=slots,
+        causal=True,
+    )
+
+    # Untouched slots (1, 3) are byte-identical.
+    for s in (1, 3):
+        torch.testing.assert_close(k_cache[s], before_k[s])
+        torch.testing.assert_close(v_cache[s], before_v[s])
+
+    ref = _reference(
+        q,
+        k_cache[slots.long()],
+        v_cache[slots.long()],
+        seqlens_all[slots.long()] + 1,
+        causal=True,
+    )
+    torch.testing.assert_close(out, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_incremental_decode_matches_prefill():
+    """Token-by-token decode == one prefill over the same sequence."""
+    T = 7
+    q = torch.randn(1, T, H, D)
+    k, v = torch.randn(1, T, HKV, D), torch.randn(1, T, HKV, D)
+
+    kc, vc = torch.zeros(1, S, HKV, D), torch.zeros(1, S, HKV, D)
+    prefill = _sdpa_attn_with_kvcache(
+        q, kc, vc, k=k, v=v, cache_seqlens=torch.zeros(1, dtype=torch.int32), causal=True
+    )
+
+    kc2, vc2 = torch.zeros(1, S, HKV, D), torch.zeros(1, S, HKV, D)
+    seqlens = torch.zeros(1, dtype=torch.int32)
+    steps = []
+    for t in range(T):
+        steps.append(
+            _sdpa_attn_with_kvcache(
+                q[:, t : t + 1],
+                kc2,
+                vc2,
+                k=k[:, t : t + 1],
+                v=v[:, t : t + 1],
+                cache_seqlens=seqlens,
+                causal=True,
+            )
+        )
+        seqlens += 1
+
+    torch.testing.assert_close(torch.cat(steps, dim=1), prefill, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(kc2, kc)
+
+
+def test_empty_cache_returns_zeros():
+    """No keys at all (nothing appended, seqlen 0) must not produce NaNs."""
+    k_cache, v_cache = _cache(batch=1)
+    q = torch.randn(1, 1, H, D)
+    out = _sdpa_attn_with_kvcache(
+        q, k_cache, v_cache, cache_seqlens=torch.zeros(1, dtype=torch.int32), causal=True
+    )
+    assert torch.equal(out, torch.zeros_like(out))
+
+
+def test_decoder_forward_flash_matches_forward(monkeypatch):
+    """Decoder.forward_flash (fallback kernel) == the SDPA training path."""
+    import vui.flash_compat as fc
+    from vui.model import Decoder
+
+    # Runs on CPU, so force the fallback even where flash_attn is installed.
+    monkeypatch.setattr(fc, "_impl", fc._sdpa_attn_with_kvcache)
+
+    torch.manual_seed(1)
+    dec = Decoder(
+        n_layers=2,
+        d_model=64,
+        n_heads=4,
+        n_kv_heads=2,
+        bias=False,
+        dropout=0.0,
+        max_seqlen=32,
+    ).eval()
+
+    T = 6
+    x = torch.randn(1, T, 64)
+    input_pos = torch.arange(T)
+
+    with torch.inference_mode():
+        ref = dec(x.clone(), input_pos)
+
+        dec.allocate_flash_kv_cache(1, device=x.device, dtype=torch.float32)
+        flash = dec.forward_flash(x.clone(), input_pos)
+
+        # ... and again one token at a time, reusing the KV cache.
+        dec.allocate_flash_kv_cache(1, device=x.device, dtype=torch.float32)
+        steps = [
+            dec.forward_flash(x[:, t : t + 1].clone(), input_pos[t : t + 1])
+            for t in range(T)
+        ]
+
+    torch.testing.assert_close(flash, ref, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(torch.cat(steps, dim=1), ref, atol=1e-5, rtol=1e-5)
+
+
+def test_unsupported_kwarg_is_loud():
+    k_cache, v_cache = _cache(batch=1)
+    with pytest.raises(NotImplementedError, match="softcap"):
+        _sdpa_attn_with_kvcache(
+            torch.randn(1, 1, H, D), k_cache, v_cache, causal=True, softcap=0.5
+        )
+
+
+def test_falls_back_when_gpu_has_no_kernels(monkeypatch):
+    """A launch failure on an unsupported arch switches to SDPA, once."""
+    import vui.flash_compat as fc
+
+    calls = []
+
+    def fake_flash(*args, **kwargs):
+        calls.append(1)
+        raise RuntimeError("no kernel image is available for execution on the device")
+
+    monkeypatch.setattr(fc, "_impl", fake_flash)
+
+    k_cache, v_cache = _cache(batch=1)
+    q = torch.randn(1, 1, H, D)
+    k, v = torch.randn(1, 1, HKV, D), torch.randn(1, 1, HKV, D)
+    args = dict(k=k, v=v, cache_seqlens=torch.zeros(1, dtype=torch.int32), causal=True)
+
+    out = fc.flash_attn_with_kvcache(q, k_cache, v_cache, **args)
+    assert out.shape == (1, 1, H, D) and torch.isfinite(out).all()
+    assert fc._impl is fc._sdpa_attn_with_kvcache
+
+    fc.flash_attn_with_kvcache(q, k_cache, v_cache, **args)
+    assert len(calls) == 1  # never retried the broken kernel
+
+
+def test_unrelated_runtime_error_propagates(monkeypatch):
+    import vui.flash_compat as fc
+
+    def fake_flash(*args, **kwargs):
+        raise RuntimeError("CUDA out of memory")
+
+    monkeypatch.setattr(fc, "_impl", fake_flash)
+    with pytest.raises(RuntimeError, match="out of memory"):
+        fc.flash_attn_with_kvcache(torch.randn(1, 1, H, D), *_cache(batch=1))
+    assert fc._impl is fake_flash
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_cuda_graph_capture(monkeypatch):
+    """The engine replays decode as a CUDA graph — the fallback must capture.
+
+    Mirrors `Engine._backbone_decode_body` / `_backbone_decode_body_b`: warm,
+    capture, replay, and check the replayed steps against eager execution.
+    """
+    import vui.flash_compat as fc
+    from vui.model import Decoder
+
+    monkeypatch.setattr(fc, "_impl", fc._sdpa_attn_with_kvcache)  # force fallback
+
+    torch.manual_seed(2)
+    dev, dt, d, Bs, T = "cuda", torch.bfloat16, 64, 2, 5
+    dec = Decoder(
+        n_layers=2,
+        d_model=d,
+        n_heads=4,
+        n_kv_heads=2,
+        bias=False,
+        dropout=0.0,
+        max_seqlen=32,
+    ).to(dev, dt).eval()
+    steps_in = [torch.randn(Bs, 1, d, device=dev, dtype=dt) for _ in range(T)]
+    seq_lens = None
+
+    def decode_body(x, slot_idx=None):
+        pos = seq_lens[slot_idx.long()] if slot_idx is not None else seq_lens[:Bs]
+        for i, (block, kv) in enumerate(zip(dec.blocks, dec.flash_kv_caches)):
+            x = block.forward_flash(
+                x,
+                kv,
+                dec._get_freqs(pos, i),
+                per_sample_freqs=True,
+                cache_batch_idx=slot_idx,
+            )
+        return dec.norm(x)[:, 0]
+
+    for slot_idx in (None, torch.tensor([1, 0], device=dev, dtype=torch.int32)):
+        # Eager reference.
+        dec.allocate_flash_kv_cache(Bs, device=dev, dtype=dt, max_seqlen=32)
+        seq_lens = dec.flash_kv_caches[0].seq_lens
+        with torch.inference_mode():
+            eager = []
+            for x in steps_in:
+                eager.append(decode_body(x, slot_idx).clone())
+                seq_lens += 1
+
+        # Warm, capture, replay.
+        dec.allocate_flash_kv_cache(Bs, device=dev, dtype=dt, max_seqlen=32)
+        seq_lens = dec.flash_kv_caches[0].seq_lens
+        static_in = torch.zeros(Bs, 1, d, device=dev, dtype=dt)
+        static_out = torch.zeros(Bs, d, device=dev, dtype=dt)
+
+        def body():
+            static_out.copy_(decode_body(static_in, slot_idx))
+            seq_lens[:Bs] += 1
+
+        with torch.inference_mode():
+            for _ in range(3):
+                body()
+                seq_lens.zero_()
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.inference_mode(), torch.cuda.graph(graph):
+            body()
+        seq_lens.zero_()
+
+        replayed = []
+        for t, x in enumerate(steps_in):
+            static_in.copy_(x)
+            seq_lens.fill_(t)
+            graph.replay()
+            replayed.append(static_out.clone())
+
+        for t, (got, want) in enumerate(zip(replayed, eager)):
+            torch.testing.assert_close(got, want, msg=f"step {t}, slots={slot_idx}")
+
+
+@pytest.mark.skipif(
+    not (HAS_FLASH_ATTN and torch.cuda.is_available()),
+    reason="flash_attn / CUDA not available on this platform",
+)
+def test_matches_flash_attn():
+    from flash_attn import flash_attn_with_kvcache
+
+    dev, dt = "cuda", torch.bfloat16
+    for Tq, causal, window in ((1, True, (-1, -1)), (4, True, (-1, -1)), (1, True, (3, 0))):
+        q = torch.randn(B, Tq, H, D, device=dev, dtype=dt)
+        k = torch.randn(B, Tq, HKV, D, device=dev, dtype=dt)
+        v = torch.randn(B, Tq, HKV, D, device=dev, dtype=dt)
+        seqlens = torch.tensor([0, 5, 9], dtype=torch.int32, device=dev)
+        kc = torch.randn(B, S, HKV, D, device=dev, dtype=dt)
+        vc = torch.randn(B, S, HKV, D, device=dev, dtype=dt)
+        kc2, vc2 = kc.clone(), vc.clone()
+
+        ref = flash_attn_with_kvcache(
+            q, kc, vc, k=k, v=v, cache_seqlens=seqlens.clone(),
+            causal=causal, window_size=window,
+        )
+        got = _sdpa_attn_with_kvcache(
+            q, kc2, vc2, k=k, v=v, cache_seqlens=seqlens.clone(),
+            causal=causal, window_size=window,
+        )
+        torch.testing.assert_close(kc2, kc)
+        torch.testing.assert_close(got, ref, atol=2e-2, rtol=2e-2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,9 @@ requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
     "sys_platform == 'emscripten'",
-    "sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
     "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 
@@ -446,12 +448,36 @@ wheels = [
 name = "flash-attn"
 version = "2.7.4+cu130torch2.10"
 source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "einops", marker = "sys_platform == 'linux'" },
-    { name = "torch", marker = "sys_platform == 'linux'" },
+    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl", hash = "sha256:1944f05ec136f6ab274878ae6d49a30cb8413c991e5d340f04bcf4a3886b6425" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "einops" },
+    { name = "torch" },
+]
+
+[[package]]
+name = "flash-attn"
+version = "2.8.3+cu130torch2.11"
+source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3%2Bcu130torch2.11-cp312-cp312-linux_aarch64.whl" }
+resolution-markers = [
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "einops", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3%2Bcu130torch2.11-cp312-cp312-linux_aarch64.whl", hash = "sha256:411088e8e08a8949b3e7f84211068ffbcc6bc1ce591506a7cc3b559c2445f3f9" },
 ]
 
 [package.metadata]
@@ -1991,7 +2017,8 @@ dependencies = [
     { name = "einops" },
     { name = "faster-whisper" },
     { name = "filelock" },
-    { name = "flash-attn", marker = "sys_platform == 'linux'" },
+    { name = "flash-attn", version = "2.7.4+cu130torch2.10", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "flash-attn", version = "2.8.3+cu130torch2.11", source = { url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3%2Bcu130torch2.11-cp312-cp312-linux_aarch64.whl" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "gradio" },
     { name = "httpx" },
     { name = "huggingface-hub" },
@@ -2029,7 +2056,8 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8" },
     { name = "faster-whisper", specifier = ">=1.0" },
     { name = "filelock", specifier = ">=3.16" },
-    { name = "flash-attn", marker = "sys_platform == 'linux'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl" },
+    { name = "flash-attn", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.22/flash_attn-2.8.3%2Bcu130torch2.11-cp312-cp312-linux_aarch64.whl" },
+    { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.7.12/flash_attn-2.7.4%2Bcu130torch2.10-cp312-cp312-linux_x86_64.whl" },
     { name = "gradio", specifier = ">=5.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=0.26" },


### PR DESCRIPTION
Fixes #20.

## Cause

`flash-attn` was pinned x86_64-only (dependency marker + wheel URL), so on aarch64 the module is simply absent and `MHA.forward_flash` imported it unconditionally at the first decode step — after ASR had already loaded fine, which is why the container looks healthy until the first TTS request.

## Changes

- **pyproject**: pin an aarch64 wheel (`2.8.3+cu130torch2.11-cp312`, from the mirror already used here) alongside the x86_64 one. Grace-Hopper (sm_90) and Grace-Blackwell (sm_100) run the real kernel. `uv.lock` regenerated.
- **`vui.flash_compat`** (new): pure-PyTorch SDPA implementation of `flash_attn_with_kvcache` — same semantics (in-place cache append, right-aligned causal masking, sliding window, `cache_batch_idx`, GQA), and CUDA-graph safe. Used where the kernel can't run: CPU/macOS, and Jetson parts (Orin sm_87, Thor sm_110) whose compute capability isn't in the wheel — that launch failure is caught once and attention falls back for the rest of the process. `VUI_ATTN=torch` forces it anywhere.
- **Dockerfile.stream**: drop the non-existent `[cuda]` extra.

## Testing

On an RTX 4090 (sm_89, flash-attn 2.8.3): 14/14 tests pass, including parity against the real kernel and CUDA-graph capture/replay with and without `cache_batch_idx`. On CPU: 12 pass, 2 GPU tests skip.

End-to-end `Engine` render on the fallback works, at RTF 7.1–7.7× vs 8.5–9.1× for flash at `max_seq=1024` (the gap grows with `max_seq` — the fallback attends over the whole allocated cache).

Teacher-forcing 64 real decode steps through both paths gives 100% argmax agreement; against an fp32-math reference the fallback is *closer* than flash (max |Δ| 1.88 vs 3.00, KL 1.7e-3 vs 3.1e-3). Rendering 24 seeds per path and transcribing with moonshine-medium: flash mean WER 0.019 (23/24 clean), fallback 0.067 (21/24 clean, one outlier) — no significant difference (Fisher p≈0.6).

## Not verified

No ARM hardware on hand: the aarch64 wheel importing on a real device, and the launch-failure switch firing on a real Jetson (unit-tested with a stub only).

@jitin03 — `torch.cuda.get_device_capability()` on your box would tell us whether the wheel alone fixes it, or whether you land on the SDPA fallback.
