### PR TITLE
Arm the babble gate by default on the vui-190k engine

### DIFF
--- a/src/vui/engine.py
+++ b/src/vui/engine.py
@@ -23,6 +23,7 @@ Usage (batched, B=N):
 
 from __future__ import annotations
 
+import os
 from collections import deque
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -305,8 +306,10 @@ class Engine:
         codec_dtype: torch.dtype = torch.float32,
         vocoder_ctx: int = 25,
     ):
+        self._loaded_ckpt = None
         if model is None:
             path = self.NAMES.get(name, name)
+            self._loaded_ckpt = path
             print(f"[Engine] Loading model {path} ...")
             model = Vui.from_pretrained_inf(path).cuda()
         if codec is None:
@@ -348,6 +351,24 @@ class Engine:
 
         self._free: set[int] = set(range(max_rows))
         self._rows: dict[int, Row] = {}
+
+        # Babble gate on by default when we loaded the checkpoint its probe was
+        # trained on (vui-190k). Best-effort: a missing artifact / offline box
+        # just leaves the gate off. VUI_PROBE_GATE=0 opts out;
+        # VUI_PROBE_GATE_MODE=shadow logs firings without re-rolling. The
+        # streaming server injects model= (so this skips) and arms the gate
+        # itself in tts_worker.
+        if (
+            self._loaded_ckpt
+            and "190k" in str(self._loaded_ckpt)
+            and os.environ.get("VUI_PROBE_GATE") != "0"
+        ):
+            try:
+                self.load_probe_gate(
+                    shadow=os.environ.get("VUI_PROBE_GATE_MODE", "") == "shadow"
+                )
+            except Exception as e:
+                print(f"[Engine] babble gate auto-load skipped: {e}")
 
     # ------------------------------------------------------------------
     # Construction


### PR DESCRIPTION
Trailing piece of the babble-gate work (#24) — this commit was pushed just after #24 merged, so it didn't make it onto `main`.

`Engine()` defaults to vui-190k, so auto-load its probe on construction. The streaming server already arms the gate in `tts_worker`; this closes the gap so `demo.py` and direct `Engine()` / `render()` callers get it **on by default** too — without opting in.

Best-effort: a missing artifact or offline box just leaves the gate off. `VUI_PROBE_GATE=0` opts out; `VUI_PROBE_GATE_MODE=shadow` logs firings without re-rolling.

Verified: `Engine(vui-190k)` arms the gate on construction (active); `VUI_PROBE_GATE=0` leaves it off.