### PR TITLE
Fail loudly off-CUDA, reject legacy checkpoints, MLX --render path

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,11 @@ For best results: voice-prompt transcript must match the audio word-for-word, ai
 If you need a checkpoint tuned to a specific voice for a legitimate use case (audiobooks, accessibility, game characters, dubbing of consenting performers, internal tooling), **get in touch** via [fluxions.ai](https://fluxions.ai) — we can train, license, or host one for you.
 
 ```python
+# Requires an NVIDIA GPU — Engine is built on CUDA graphs. On Apple Silicon
+# use `python demo.py` (auto-routes to MLX) or vui.mlx.tts instead.
 from vui.engine import Engine, GenConfig
 
-engine = Engine()  # loads "vui-nano" from HuggingFace by default
+engine = Engine()  # loads "vui-190k.safetensors" from HuggingFace by default
 with engine.new_row() as row:
     codes, audio = row.render(
         "So [breath] the thing about this is, it's not what you'd expect, right?",

--- a/src/vui/demo/cli.py
+++ b/src/vui/demo/cli.py
@@ -22,6 +22,8 @@ def run(
 ):
     if text is None:
         raise SystemExit("--render requires text: python demo.py --render [ckpt] \"text\"")
+    if not torch.cuda.is_available():
+        return run_mlx(checkpoint_path, prompt_file, text, **overrides)
     from vui.model import Vui
 
     torch.set_float32_matmul_precision("high")
@@ -121,3 +123,63 @@ def run(
             print("  Generation failed")
 
     state.teardown()
+
+
+def run_mlx(
+    checkpoint_path: str,
+    prompt_file: str = "prompts/harry.wav",
+    text: str | None = None,
+    **overrides,
+):
+    """MLX one-shot render (Apple Silicon / no CUDA). Reuses MLXTTSEngine."""
+    import queue
+    import threading
+
+    from vui.serving.stream.tts_worker_mlx import MLXTTSEngine
+
+    engine = MLXTTSEngine.from_checkpoint(checkpoint_path)
+
+    settings = {
+        "temperature": 0.9,
+        "max_duration": overrides.get("max_secs", 30.0),
+        "n_codebooks": overrides.get("n_codebooks", 0),
+    }
+    if "temperature" in overrides:
+        settings["temperature"] = overrides["temperature"]
+
+    prompt_path = Path(prompt_file)
+    if prompt_path.exists():
+        engine._load_prompt_by_name(prompt_path.stem, settings)
+
+    out_dir = Path("outputs")
+    out_dir.mkdir(exist_ok=True)
+
+    audio_queue: queue.Queue = queue.Queue()
+    t0 = time.perf_counter()
+    engine.generate(
+        simple_clean(text), settings, threading.Event(), audio_queue=audio_queue
+    )
+    dt = time.perf_counter() - t0
+
+    audio_chunks = []
+    while not audio_queue.empty():
+        msg = audio_queue.get_nowait()
+        if msg.get("type") == "audio":
+            audio_chunks.append(msg["data"])
+
+    if not audio_chunks:
+        print("  Generation failed")
+        return
+
+    full_audio = torch.cat(audio_chunks, dim=-1)
+    dur = full_audio.shape[-1] / QWEN_SR
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    save_file = str(out_dir / f"render_{ts}.wav")
+    encoded = AudioEncoder(
+        full_audio.squeeze().cpu().float().unsqueeze(0), sample_rate=int(QWEN_SR)
+    )
+    encoded.to_file(save_file)
+    print(f"  {dur:.1f}s in {dt:.2f}s ({dur/dt:.1f}x RTF) -> {save_file}")
+    subprocess.Popen(
+        ["play", save_file], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )

--- a/src/vui/engine.py
+++ b/src/vui/engine.py
@@ -306,6 +306,13 @@ class Engine:
         codec_dtype: torch.dtype = torch.float32,
         vocoder_ctx: int = 25,
     ):
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "Engine requires CUDA — it captures CUDA graphs for decode. "
+                "On Apple Silicon use the MLX path instead: `python demo.py` "
+                "(auto-routes to MLX) or vui.mlx.tts; see 'Apple Silicon "
+                "status' in the README."
+            )
         self._loaded_ckpt = None
         if model is None:
             path = self.NAMES.get(name, name)

--- a/src/vui/mlx/tts/weights.py
+++ b/src/vui/mlx/tts/weights.py
@@ -128,7 +128,7 @@ def load_model(
 
 
 def torch_to_mlx(t) -> mx.array:
-    return mx.array(t.float().numpy())
+    return mx.array(t.detach().float().numpy())
 
 
 def load_from_pytorch(checkpoint_path: str) -> tuple[VuiMLX, dict]:
@@ -154,6 +154,9 @@ def load_from_pytorch(checkpoint_path: str) -> tuple[VuiMLX, dict]:
         k.replace("module.", "").replace("text_embedding.", "token_emb."): v
         for k, v in raw_state.items()
     }
+    from vui.model import reject_legacy_checkpoint
+
+    reject_legacy_checkpoint(pt_state, source=checkpoint_path)
 
     # Infer sq_input_dim from weight shape (default 6, but some checkpoints use 7)
     sq_w_key = "sq_proj.proj.0.weight"

--- a/src/vui/model.py
+++ b/src/vui/model.py
@@ -12,6 +12,23 @@ from vui.rope import apply_rotary_emb, precompute_freqs_cis
 from vui.tokenizer import VuiTokenizer
 
 
+# Key layout of the original-release checkpoints (vui-cohost-100m.pt etc.),
+# which predate the rq_transformer architecture. They bind to nothing in the
+# current model and must be rejected loudly rather than half-loaded.
+LEGACY_CHECKPOINT_KEYS = ("audio_embeddings.0.weight", "audio_heads.0.weight")
+
+
+def reject_legacy_checkpoint(state_dict: dict, source: str = "checkpoint"):
+    if any(k in state_dict for k in LEGACY_CHECKPOINT_KEYS):
+        raise ValueError(
+            f"{source} is a legacy checkpoint from the original vui release "
+            "(per-quantizer audio_embeddings/audio_heads, no rq_transformer) "
+            "and does not match the current architecture. Use "
+            "'vui-190k.safetensors' (default) or 'vui-nano.safetensors' from "
+            "https://huggingface.co/fluxions/vui instead."
+        )
+
+
 def load_what_you_can(checkpoint: dict, model: nn.Module):
     """Load as many weights from `checkpoint` as possible.
 
@@ -1191,6 +1208,10 @@ class Vui(nn.Module):
         config = Config(**config)
 
         state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
+        reject_legacy_checkpoint(
+            state_dict,
+            source=checkpoint_path if isinstance(checkpoint_path, str) else "checkpoint",
+        )
         state_dict = {
             k.replace("text_embedding.", "token_emb."): v for k, v in state_dict.items()
         }


### PR DESCRIPTION
Fixes #27.

**`Engine` off CUDA** — raises a clear `RuntimeError` pointing at the MLX path (`python demo.py` / `vui.mlx.tts`) instead of dying inside `.cuda()`.

**Legacy checkpoints** — the code targets `vui-190k.safetensors` (default) and `vui-nano.safetensors`, both on [fluxions/vui](https://huggingface.co/fluxions/vui). The `*100m.pt` files are from the original-release architecture (per-quantizer `audio_embeddings`/`audio_heads`, no rq_transformer) and used to half-load with `rq_transformer=None` after 'Ignoring parameter' warnings. Both the torch and MLX loaders now reject them with a message naming the current checkpoints.

**`torch_to_mlx`** — detaches before `.numpy()`; the legacy `.pt` carries `requires_grad` on all tensors and reproduced the reported error exactly.

**`demo.py --render` on Apple Silicon** — previously CUDA-only (it exited into `vui/demo/cli.py` before the MLX auto-detection ran); now routes to a one-shot MLX render reusing `MLXTTSEngine`. Verified on M-series: renders at 1.2–2.7× RTF, output transcribes back word-perfect.

Also fixes the stale README comment (`Engine()` defaults to vui-190k, not vui-nano) and marks the Python-API example CUDA-only.