### PR TITLE
MLX Engine backend, legacy (pre-1.0) checkpoint support, CLI consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Vui is a real-time voice assistant: speak into your mic, the model transcribes, 
 - **Built-in web search** — single-query factual lookups ("weather in London", "price of X", "who won the match") via Serper, Brave, or Tavily — one API round-trip, no agent loop; falls through to `delegate` for multi-step research
 - **Optional Claude task server** — sidecar agent that handles slow/agentic work (Gmail, Calendar, Drive, Slack, multi-step web research) via your existing Claude Code MCPs; auto-discovered on boot
 - **Non-Anthropic task backends** — point the task server at Ollama, z.ai, DeepSeek, vLLM, LM Studio, LiteLLM via the Anthropic-compatible `/v1/messages` envelope
-- **Apple Silicon support** — MLX TTS inference works (quantized vui-190k, pre-baked weights auto-download, ~1.5× real-time on M4); the rest of the MLX stack is WIP
+- **Apple Silicon support** — the `Engine` Python API auto-dispatches to an MLX backend (quantized vui-190k, pre-baked weights auto-download, ~1.5–2.7× real-time on M4), `demo.py` and `demo.py --render` work end-to-end; the streaming-server MLX glue is WIP
 - **Mobile-ready** — documented cloudflared and Tailscale paths for phone access with mic over HTTPS
 - **Docker compose** — one file brings up the full stack (streaming server + optional bundled Ollama + optional Claude task server)
 - **OpenClaw integration** — point OpenClaw's `openai` realtime provider at Vui for a fully-local voice front-end
@@ -147,7 +147,7 @@ vLLM and other OpenAI-compatible backends are also supported (`VUI_LLM_BACKEND=v
 **Apple Silicon — MLX auto-setup (~1.9× faster decode, recommended):**
 On first run the server auto-creates `qwen3.5-4b-mlx` via `ollama create --experimental --quantize int4` (~37 tok/s decode vs ~19 tok/s for GGUF Q4 on the same 4B model). Falls back to `qwen3.5:4b` GGUF if MLX setup fails. `--experimental` is required — without it Ollama converts to GGUF and you lose the speedup.
 
-> **Apple Silicon status.** TTS inference on MLX **works**: `vui.mlx.tts.*` renders voice-prompted speech end-to-end (int8 vui-190k, ~1.5× real-time on M4), and the pre-baked quantized weights auto-download on first run — no torch conversion step. The **rest of the MLX stack is WIP**: MLX-Moonshine ASR, streaming-server glue, the `qwen3.5-4b-mlx` Ollama variant, and the docker-compose story haven't had the same polish as the CUDA path. If you're a Mac user who'd like to help shake out rough edges — kernel perf, streaming stability on M-series — we'd love contributors. Open an issue or PR on the repo, or get in touch via [fluxions.ai](https://fluxions.ai).
+> **Apple Silicon status.** TTS on MLX **works**: `Engine()` auto-dispatches to a single-row MLX backend with the same Row API (prefill / render / stream / rewind), `python demo.py` and `demo.py --render` run end-to-end (int8 vui-190k, ~1.5–2.7× real-time on M4), and the pre-baked quantized weights auto-download on first run — no torch conversion step. Even the [pre-1.0 legacy checkpoints](docs/legacy.md) run with an MLX decoder. The **rest of the MLX stack is WIP**: MLX-Moonshine ASR, streaming-server glue, the `qwen3.5-4b-mlx` Ollama variant, and the docker-compose story haven't had the same polish as the CUDA path. If you're a Mac user who'd like to help shake out rough edges — kernel perf, streaming stability on M-series — we'd love contributors. Open an issue or PR on the repo, or get in touch via [fluxions.ai](https://fluxions.ai).
 
 ### TTS demo on its own
 ```sh
@@ -287,8 +287,9 @@ For best results: voice-prompt transcript must match the audio word-for-word, ai
 If you need a checkpoint tuned to a specific voice for a legitimate use case (audiobooks, accessibility, game characters, dubbing of consenting performers, internal tooling), **get in touch** via [fluxions.ai](https://fluxions.ai) — we can train, license, or host one for you.
 
 ```python
-# Requires an NVIDIA GPU — Engine is built on CUDA graphs. On Apple Silicon
-# use `python demo.py` (auto-routes to MLX) or vui.mlx.tts instead.
+# On NVIDIA this is the CUDA-graph engine (continuous batching, streaming);
+# on Apple Silicon Engine() auto-dispatches to a single-row MLX backend with
+# the same Row API (prefill / render / stream / rewind).
 from vui.engine import Engine, GenConfig
 
 engine = Engine()  # loads "vui-190k.safetensors" from HuggingFace by default
@@ -298,6 +299,8 @@ with engine.new_row() as row:
         GenConfig(temperature=0.7),
     )
 ```
+
+**Original-release (pre-1.0) checkpoints** — `vui-100m-base.pt`, `vui-cohost-100m.pt`, `vui-abraham-100m.pt` — use an older architecture and don't load into `Engine`. They still work via `vui.legacy`: `from vui.legacy import Vui, render; audio = render(Vui.from_pretrained("vui-cohost-100m.pt").eval(), "Hello!")` (22 kHz output, faster than real-time on CPU — no GPU or flash-attn needed). On Apple Silicon, `vui.mlx.legacy.load_legacy_mlx` runs the transformer on MLX at ~4.5× real-time. Details: [`docs/legacy.md`](docs/legacy.md).
 
 **Tip: try turning repetition penalty off.** `GenConfig` defaults `rep_penalty=1.1` to break long silence/filler loops, but it can flatten prosody and distort natural repetition. Setting it to `0` (anything `<= 1.0` disables the penalty path, see `inference.py:539`) often gives more natural-sounding output — worth trying if generations sound stilted or over-corrected.
 

--- a/docs/legacy.md
+++ b/docs/legacy.md
@@ -1,0 +1,67 @@
+# Legacy (pre-1.0) checkpoints
+
+The original vui release shipped 100M-parameter checkpoints on a different
+architecture from today's models. They don't load into `Engine` — the loaders
+reject them with a pointer here — but they still run via `vui.legacy`.
+
+| Checkpoint | Notes |
+|-----------------------|--------------------------------------------|
+| `vui-100m-base.pt` | base model |
+| `vui-cohost-100m.pt` | two-speaker conversational fine-tune |
+| `vui-abraham-100m.pt` | single-voice fine-tune |
+
+All auto-download from [fluxions/vui](https://huggingface.co/fluxions/vui),
+as does their codec (`fluac-22hz-22khz.pt`, 22.05 kHz output).
+
+## How they differ from current checkpoints
+
+- Per-quantizer audio embeddings and heads (9 quantizers, codebook 1000)
+  decoded with a **delayed codebook pattern** — no RQ-transformer.
+- **Fluac** codec at 22.05 kHz instead of the Qwen codec at 24 kHz.
+- byt5 text tokenizer, no speaker-embedding prompting, no sq/wps conditioning.
+
+## Usage
+
+```python
+from vui.legacy import Vui, render
+
+model = Vui.from_pretrained("vui-cohost-100m.pt").eval()
+audio = render(model, "Hello there!")  # (1, 1, S) float at 22050 Hz
+```
+
+Runs on **CUDA** or **CPU** (no flash-attn; faster than real-time on an
+M-series CPU). `render` accepts `prompt_codes` for continuation,
+`temperature`, `top_k`, `top_p`, and `max_secs`; texts over 1000 characters
+are chunked line-by-line with rolling code context, as in the original
+release.
+
+### Apple Silicon: MLX decoder (~4.5× real-time)
+
+`vui.mlx.legacy` runs the transformer on MLX while embeddings, heads,
+sampling, and the Fluac codec stay on (fast, tiny) torch-CPU ops:
+
+```python
+from vui.legacy import render
+from vui.mlx.legacy import load_legacy_mlx
+
+model, adapter = load_legacy_mlx("vui-cohost-100m.pt")
+audio = render(model, "Hello there!", decoder=adapter)
+```
+
+Measured on M4: ~4.5× real-time (vs ~1.3× pure CPU), TTFB ~115 ms. The MLX
+decoder matches the torch decoder to ~3e-4 max abs difference (fp32).
+
+## Limitations
+
+- **MPS is refused.** `generate` raises on a model moved to MPS: torch-on-Metal
+  produces corrupted audio for this architecture and is slower than CPU.
+  Use CPU, CUDA, or the MLX adapter.
+- **VAD trimming is optional.** The original release trimmed output with
+  pyannote VAD, which is no longer a dependency. Without it installed the
+  full untrimmed render is returned.
+- **Old-model quirks are preserved**, not fixed: occasional early EOS can
+  clip trailing words, and the generation loop trims the last 10 frames
+  (~0.5 s) as the original code did.
+- Batch size 1 only; no streaming API. For streaming, batching, voice
+  prompting, and better quality, use the current checkpoints via
+  [`Engine`](python-api.md).

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -2,7 +2,7 @@
 
 Most users will reach `vui.engine.Engine` directly — for one-shot rendering, batch jobs, custom pipelines, or anywhere the streaming server's HTTP/WS surface is overkill. This doc covers the public API: loading, prompt encoding (with proper multi-segment chunking for long references), rendering, and streaming.
 
-CUDA-only. For the Apple-Silicon MLX path see [the bottom of this doc](#apple-silicon-mlx).
+On Apple Silicon, `Engine()` auto-dispatches to a single-row MLX backend with the same Row API — see [the bottom of this doc](#apple-silicon-mlx) for what differs. Continuous batching (`max_rows > 1`, `render_continuous` / `render_all`) is CUDA-only.
 
 ## Minimal example
 
@@ -223,17 +223,31 @@ The `ctx=6` parameter prepends 6 frames (~500ms) of codec context to smooth chun
 
 **Status:** TTS inference on MLX is working — quantized vui-190k renders voice-prompted speech end-to-end at ~1.5× real-time on M4, and `load_quantized` auto-downloads the pre-baked int8/int4 weights (no torch float32-load-and-quantize step; torch is still used to encode prompt audio). The wider MLX stack (ASR, streaming-server integration) is still WIP.
 
-The MLX path is a separate code surface (`vui.mlx.tts.*`) — same model, different runtime. The end-to-end equivalent of the chunked-prompt flow above is `demo.py:generate_chunked_mlx` (lines ~167–275). Key differences:
+**`Engine()` works here.** On a machine without CUDA, `Engine()` returns `vui.mlx.engine.MLXEngine`, which implements the same Row API (`prefill` / `add_user` / `render` / `stream` / `rewind` / `reset`) backed by MLX — so the minimal example above runs unchanged. What differs from the CUDA engine:
 
-- Loaded via `vui.mlx.tts.weights.load_quantized(ckpt_path, "float32"|"int8"|"int4")`.
-- No `Engine` class; you call `vui.mlx.tts.generate.generate` per chunk and the prompt is prefilled via `vui.mlx.tts.generate.prefill_prompt` (single segment) or by manually iterating segments with `[spk] [text_i] [audio_i]` (`_prefill_segments_mlx` in demo.py).
-- No streaming primitive — chunks are generated one at a time and concatenated.
+- **Single row only.** `max_rows` must be 1; continuous batching (`render_continuous` / `render_all`) and two-speaker prefill are CUDA-only.
+- **No gates.** The entropy gate (`gate_frames`) and babble probe gate aren't wired up; those `GenConfig` fields are ignored. Repetition-penalty state is per-chunk rather than per-render-call.
+- **Precision.** Loads int8 quantized weights by default (`VUI_MLX_PRECISION=float32|int8|int4` to override); the pre-baked weights auto-download on first run.
+- **Official voices need no torch encoder.** `vui.mlx.engine.load_official_prompt("maeve")` returns `(transcript, codes, spk_token, cond_bias)` from the pre-baked HF prompt safetensors:
 
-If you're on M-series and want chunked-prompt MLX rendering, mirror `generate_chunked_mlx`'s `_prefill_segments_mlx` call after building segments with `build_prompt_segments` (the prompt-utils function is backend-agnostic; only the encoder callback needs to be MLX-friendly).
+```python
+from vui.engine import Engine, GenConfig, Segment
+from vui.mlx.engine import load_official_prompt
+
+engine = Engine()
+text, codes, spk_token, cond_bias = load_official_prompt("maeve")
+engine.cond_bias = cond_bias
+with engine.new_row() as row:
+    row.prefill([Segment(text=text, codes=codes)], spk_emb=spk_token)
+    codes_out, audio = row.render("Hello!", GenConfig(temperature=0.7))
+```
+
+For arbitrary voice prompts, build segments with `build_prompt_segments` as on CUDA — encoding prompt audio still uses the torch codec encoder (CPU is fine). The lower-level primitives (`vui.mlx.tts.generate`, `vui.mlx.tts.stream.TTSStream`) remain available for custom loops.
 
 ## See also
 
 - [`prompting.md`](prompting.md) — text-side rules (tags, punctuation, phonetic numbers, `|spell|` escape for hard words).
+- [`legacy.md`](legacy.md) — running the original-release (pre-1.0) 100M checkpoints via `vui.legacy`, including the MLX decoder for Apple Silicon.
 - [`memory-budget.md`](memory-budget.md) — VRAM breakdown per component, `n_codebooks` tradeoffs, `max_rows` budgeting.
 - [`configuration.md`](configuration.md) — env-var overrides for the streaming server's defaults.
 - `src/vui/demo/cli.py` — full working CLI render with streaming playback, prompt loading, settings, and tab-completion.

--- a/src/vui/demo/cli.py
+++ b/src/vui/demo/cli.py
@@ -125,60 +125,96 @@ def run(
     state.teardown()
 
 
+def _mlx_prompt(engine, row, prompt_file: str) -> bool:
+    """Prefill `row` with a voice prompt. Official voices (maeve/abraham/...)
+    use the pre-baked HF safetensors; other wavs are encoded locally with the
+    torch codec encoder + a sibling .txt transcript (mlx_whisper if missing)."""
+    from vui.engine import Segment
+    from vui.mlx.engine import load_official_prompt
+
+    voice = Path(prompt_file).stem
+    try:
+        text, codes, spk_token, cond_bias = load_official_prompt(voice)
+        if cond_bias is not None:
+            engine.cond_bias = cond_bias
+        row.prefill([Segment(text=text, codes=codes)], spk_emb=spk_token)
+        print(f"  Prompt '{voice}': '{text[:60]}' ({codes.shape[0]} frames)")
+        return True
+    except Exception:
+        pass
+
+    if not Path(prompt_file).exists():
+        print(f"  No prompt at {prompt_file}; rendering unprompted")
+        return False
+
+    from julius.resample import resample_frac
+
+    from vui.qwen_codec import QwenCodecEncoder
+    from vui.qwen_spk_enc import QwenSpeakerEncoder
+
+    wav = AudioDecoder(prompt_file, sample_rate=16000, num_channels=1)
+    audio_16k = wav.get_all_samples().data.squeeze(0)
+    audio_24k = resample_frac(audio_16k.unsqueeze(0), 16000, QWEN_SR)
+
+    txt_path = Path(prompt_file).with_suffix(".txt")
+    if txt_path.exists():
+        text = txt_path.read_text().strip()
+    else:
+        import mlx_whisper
+
+        text = mlx_whisper.transcribe(
+            audio_16k.numpy(),
+            path_or_hf_repo="mlx-community/whisper-large-v3-turbo",
+            language="en",
+            verbose=False,
+        )["text"].strip()
+
+    enc = QwenCodecEncoder.from_pretrained().cpu().float().eval()
+    with torch.inference_mode():
+        codes = enc.encode(audio_24k.float().unsqueeze(0))
+    codes_tq = codes[0, : engine.Q].T.long().cpu()
+    spk_emb = QwenSpeakerEncoder.from_pretrained().embed(
+        audio_24k.squeeze(0), sr=int(QWEN_SR)
+    )
+    row.prefill([Segment(text=text, codes=codes_tq)], spk_emb=spk_emb)
+    print(f"  Prompt (encoded): '{text[:60]}' ({codes_tq.shape[0]} frames)")
+    return True
+
+
 def run_mlx(
     checkpoint_path: str,
     prompt_file: str = "prompts/harry.wav",
     text: str | None = None,
     **overrides,
 ):
-    """MLX one-shot render (Apple Silicon / no CUDA). Reuses MLXTTSEngine."""
-    import queue
-    import threading
+    """MLX one-shot render (Apple Silicon / no CUDA) via the Engine API."""
+    from vui.engine import Engine, GenConfig
 
-    from vui.serving.stream.tts_worker_mlx import MLXTTSEngine
-
-    engine = MLXTTSEngine.from_checkpoint(checkpoint_path)
-
-    settings = {
-        "temperature": 0.9,
-        "max_duration": overrides.get("max_secs", 30.0),
-        "n_codebooks": overrides.get("n_codebooks", 0),
-    }
-    if "temperature" in overrides:
-        settings["temperature"] = overrides["temperature"]
-
-    prompt_path = Path(prompt_file)
-    if prompt_path.exists():
-        engine._load_prompt_by_name(prompt_path.stem, settings)
+    engine = Engine(checkpoint_path)
+    cfg = GenConfig(
+        temperature=overrides.get("temperature", 0.9),
+        max_secs=overrides.get("max_secs", 30.0),
+        eos_threshold=overrides.get("eos_threshold", 0.45),
+        n_codebooks=overrides.get("n_codebooks", 0),
+    )
 
     out_dir = Path("outputs")
     out_dir.mkdir(exist_ok=True)
 
-    audio_queue: queue.Queue = queue.Queue()
-    t0 = time.perf_counter()
-    engine.generate(
-        simple_clean(text), settings, threading.Event(), audio_queue=audio_queue
-    )
-    dt = time.perf_counter() - t0
+    with engine.new_row() as row:
+        _mlx_prompt(engine, row, prompt_file)
+        t0 = time.perf_counter()
+        _codes, full_audio = row.render(simple_clean(text), cfg)
+        dt = time.perf_counter() - t0
 
-    audio_chunks = []
-    while not audio_queue.empty():
-        msg = audio_queue.get_nowait()
-        if msg.get("type") == "audio":
-            audio_chunks.append(msg["data"])
-
-    if not audio_chunks:
+    if full_audio.shape[-1] == 0:
         print("  Generation failed")
         return
 
-    full_audio = torch.cat(audio_chunks, dim=-1)
     dur = full_audio.shape[-1] / QWEN_SR
     ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     save_file = str(out_dir / f"render_{ts}.wav")
-    encoded = AudioEncoder(
-        full_audio.squeeze().cpu().float().unsqueeze(0), sample_rate=int(QWEN_SR)
-    )
-    encoded.to_file(save_file)
+    AudioEncoder(full_audio.squeeze(0), sample_rate=int(QWEN_SR)).to_file(save_file)
     print(f"  {dur:.1f}s in {dt:.2f}s ({dur/dt:.1f}x RTF) -> {save_file}")
     subprocess.Popen(
         ["play", save_file], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL

--- a/src/vui/engine.py
+++ b/src/vui/engine.py
@@ -295,6 +295,22 @@ class Engine:
         "vui-190k": "vui-190k.safetensors",
     }
 
+    def __new__(cls, *args, **kwargs):
+        if cls is Engine and not torch.cuda.is_available():
+            try:
+                from vui.mlx.engine import MLXEngine
+            except ImportError as e:
+                raise RuntimeError(
+                    "Engine requires CUDA — it captures CUDA graphs for "
+                    "decode — and the MLX fallback is unavailable "
+                    f"({e}). On Apple Silicon install the mlx extra "
+                    "(`uv sync --extra mlx`); other platforms need an "
+                    "NVIDIA GPU."
+                ) from e
+            print("[Engine] No CUDA — using MLX backend (single row)")
+            return MLXEngine(*args, **kwargs)
+        return super().__new__(cls)
+
     def __init__(
         self,
         name: str = "vui-190k",
@@ -306,13 +322,6 @@ class Engine:
         codec_dtype: torch.dtype = torch.float32,
         vocoder_ctx: int = 25,
     ):
-        if not torch.cuda.is_available():
-            raise RuntimeError(
-                "Engine requires CUDA — it captures CUDA graphs for decode. "
-                "On Apple Silicon use the MLX path instead: `python demo.py` "
-                "(auto-routes to MLX) or vui.mlx.tts; see 'Apple Silicon "
-                "status' in the README."
-            )
         self._loaded_ckpt = None
         if model is None:
             path = self.NAMES.get(name, name)

--- a/src/vui/legacy/__init__.py
+++ b/src/vui/legacy/__init__.py
@@ -1,0 +1,25 @@
+"""Support for the original-release (pre-1.0) 100M checkpoints.
+
+These use the old architecture — per-quantizer audio embeddings/heads with a
+delayed codebook pattern, and the Fluac 22 kHz codec — and do not load into
+the current model. Usage:
+
+    from vui.legacy import Vui, render
+    model = Vui.from_pretrained("vui-cohost-100m.pt").eval()
+    audio = render(model, "Hello there!")  # (1, 1, S) at 22050 Hz
+
+Checkpoints: vui-100m-base.pt, vui-cohost-100m.pt, vui-abraham-100m.pt
+(auto-downloaded from https://huggingface.co/fluxions/vui). Runs on CUDA or
+CPU — no flash-attn required (MPS is refused: numerically broken there).
+
+On Apple Silicon, run the transformer on MLX (~3.4x faster than CPU):
+
+    from vui.mlx.legacy import load_legacy_mlx
+    model, adapter = load_legacy_mlx("vui-cohost-100m.pt")
+    audio = render(model, "Hello!", decoder=adapter)
+"""
+
+from vui.legacy.inference import generate, render
+from vui.legacy.model import Vui
+
+__all__ = ["Vui", "generate", "render"]

--- a/src/vui/legacy/config.py
+++ b/src/vui/legacy/config.py
@@ -1,0 +1,41 @@
+import sys
+
+from pydantic import BaseModel
+
+
+class VuiConfig(BaseModel):
+    max_text_tokens: int = 100
+    text_size: int = -1
+    max_audio_tokens: int = 100
+
+    n_quantizers: int = 9
+    codebook_size: int = 1000
+    special_token_id: int = 1000
+    audio_eos_id: int = 1000 + 1
+    audio_pad_id: int = 1000 + 1 + 1
+    d_model: int = 512
+    n_layers: int = 6
+    n_heads: int = 8
+    bias: bool = False
+    dropout: float = 0.0
+    use_rotary_emb: bool = True
+    rope_dim: int | None = None
+    rope_theta: float = 10_000.0
+    rope_theta_rescale_factor: float = 1.0
+
+
+class Config(BaseModel):
+    name: str = "base"
+
+    checkpoint: str | dict | None = None
+
+    model: VuiConfig = VuiConfig()
+
+
+ALL = []
+current_module = sys.modules[__name__]
+for name in dir(current_module):
+    if name.isupper() and isinstance(getattr(current_module, name), Config):
+        ALL.append(getattr(current_module, name))
+
+CONFIGS = {v.name: v for v in ALL}

--- a/src/vui/legacy/fluac.py
+++ b/src/vui/legacy/fluac.py
@@ -1,0 +1,709 @@
+import math
+from contextlib import nullcontext
+from functools import partial, wraps
+from os import path
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import pack, rearrange, unpack
+from einops.layers.torch import Rearrange
+from pydantic import BaseModel
+from torch import Tensor, int32
+from torch.amp import autocast
+from torch.nn import Module
+from torch.nn.utils.parametrizations import weight_norm
+
+def decompile_state_dict(state_dict):
+    state_dict = {k.replace("_orig_mod.", ""): v for k, v in state_dict.items()}
+    return {k.replace("module.", ""): v for k, v in state_dict.items()}
+
+
+def exists(v):
+    return v is not None
+
+
+def default(*args):
+    for arg in args:
+        if exists(arg):
+            return arg
+    return None
+
+
+def maybe(fn):
+    @wraps(fn)
+    def inner(x, *args, **kwargs):
+        if not exists(x):
+            return x
+        return fn(x, *args, **kwargs)
+
+    return inner
+
+
+def pack_one(t, pattern):
+    return pack([t], pattern)
+
+
+def unpack_one(t, ps, pattern):
+    return unpack(t, ps, pattern)[0]
+
+
+def round_ste(z: Tensor) -> Tensor:
+    """Round with straight through gradients."""
+    zhat = z.round()
+    return z + (zhat - z).detach()
+
+
+class FSQ(Module):
+    def __init__(
+        self,
+        levels: List[int],
+        dim: int | None = None,
+        num_codebooks: int = 1,
+        keep_num_codebooks_dim: bool | None = None,
+        allowed_dtypes: Tuple[torch.dtype, ...] = (torch.float32, torch.float64),
+        channel_first: bool = True,
+        projection_has_bias: bool = True,
+        return_indices=True,
+        force_quantization_f32: bool = True,
+    ):
+        super().__init__()
+
+        _levels = torch.tensor(levels, dtype=int32)
+        self.register_buffer("_levels", _levels, persistent=False)
+
+        _basis = torch.cumprod(torch.tensor([1] + levels[:-1]), dim=0, dtype=int32)
+        self.register_buffer("_basis", _basis, persistent=False)
+
+        codebook_dim = len(levels)
+        self.codebook_dim = codebook_dim
+
+        effective_codebook_dim = codebook_dim * num_codebooks
+        self.num_codebooks = num_codebooks
+        self.effective_codebook_dim = effective_codebook_dim
+
+        keep_num_codebooks_dim = default(keep_num_codebooks_dim, num_codebooks > 1)
+        assert not (num_codebooks > 1 and not keep_num_codebooks_dim)
+        self.keep_num_codebooks_dim = keep_num_codebooks_dim
+
+        self.dim = default(dim, len(_levels) * num_codebooks)
+
+        self.channel_first = channel_first
+
+        has_projections = self.dim != effective_codebook_dim
+        self.project_in = (
+            nn.Linear(self.dim, effective_codebook_dim, bias=projection_has_bias)
+            if has_projections
+            else nn.Identity()
+        )
+        self.project_out = (
+            nn.Linear(effective_codebook_dim, self.dim, bias=projection_has_bias)
+            if has_projections
+            else nn.Identity()
+        )
+
+        self.has_projections = has_projections
+
+        self.return_indices = return_indices
+        if return_indices:
+            self.codebook_size = self._levels.prod().item()
+            implicit_codebook = self._indices_to_codes(torch.arange(self.codebook_size))
+            self.register_buffer(
+                "implicit_codebook", implicit_codebook, persistent=False
+            )
+
+        self.allowed_dtypes = allowed_dtypes
+        self.force_quantization_f32 = force_quantization_f32
+
+    def bound(self, z, eps: float = 1e-3):
+        """Bound `z`, an array of shape (..., d)."""
+        half_l = (self._levels - 1) * (1 + eps) / 2
+        offset = torch.where(self._levels % 2 == 0, 0.5, 0.0)
+        shift = (offset / half_l).atanh()
+        return (z + shift).tanh() * half_l - offset
+
+    def quantize(self, z):
+        """Quantizes z, returns quantized zhat, same shape as z."""
+        quantized = round_ste(self.bound(z))
+        half_width = self._levels // 2  # Renormalize to [-1, 1].
+        return quantized / half_width
+
+    def _scale_and_shift(self, zhat_normalized):
+        half_width = self._levels // 2
+        return (zhat_normalized * half_width) + half_width
+
+    def _scale_and_shift_inverse(self, zhat):
+        half_width = self._levels // 2
+        return (zhat - half_width) / half_width
+
+    def _indices_to_codes(self, indices):
+        level_indices = self.indices_to_level_indices(indices)
+        codes = self._scale_and_shift_inverse(level_indices)
+        return codes
+
+    def codes_to_indices(self, zhat):
+        """Converts a `code` to an index in the codebook."""
+        assert zhat.shape[-1] == self.codebook_dim
+        zhat = self._scale_and_shift(zhat)
+        return (zhat * self._basis).sum(dim=-1).to(int32)
+
+    def indices_to_level_indices(self, indices):
+        """Converts indices to indices at each level, perhaps needed for a transformer with factorized embeddings"""
+        indices = rearrange(indices, "... -> ... 1")
+        codes_non_centered = (indices // self._basis) % self._levels
+        return codes_non_centered
+
+    def indices_to_codes(self, indices):
+        """Inverse of `codes_to_indices`."""
+        assert exists(indices)
+
+        is_img_or_video = indices.ndim >= (3 + int(self.keep_num_codebooks_dim))
+
+        codes = self._indices_to_codes(indices)
+
+        if self.keep_num_codebooks_dim:
+            codes = rearrange(codes, "... c d -> ... (c d)")
+
+        codes = self.project_out(codes)
+
+        if is_img_or_video or self.channel_first:
+            codes = rearrange(codes, "b ... d -> b d ...")
+
+        return codes
+
+    def forward(self, z: Tensor):
+        """
+        einstein notation
+        b - batch
+        n - sequence (or flattened spatial dimensions)
+        d - feature dimension
+        c - number of codebook dim
+        """
+        device_type = z.device.type
+
+        with torch.autocast(device_type=device_type, enabled=False):
+            if self.channel_first:
+                z = rearrange(z, "b d ... -> b ... d")
+                z, ps = pack_one(z, "b * d")
+
+            assert (
+                z.shape[-1] == self.dim
+            ), f"expected dimension of {self.dim} but found dimension of {z.shape[-1]}"
+
+            z = self.project_in(z)
+
+            z = rearrange(z, "b n (c d) -> b n c d", c=self.num_codebooks)
+
+            # whether to force quantization step to be full precision or not
+
+            force_f32 = self.force_quantization_f32
+            quantization_context = (
+                partial(autocast, device_type=device_type, enabled=False)
+                if force_f32
+                else nullcontext
+            )
+
+            with quantization_context():
+                orig_dtype = z.dtype
+
+                if force_f32 and orig_dtype not in self.allowed_dtypes:
+                    z = z.float()
+
+                codes = self.quantize(z)
+
+                # returning indices could be optional
+
+                indices = None
+
+                if self.return_indices:
+                    indices = self.codes_to_indices(codes)
+
+                codes = rearrange(codes, "b n c d -> b n (c d)")
+
+                codes = codes.type(orig_dtype)
+
+            # project out
+
+            out = self.project_out(codes)
+
+            # reconstitute image or video dimensions
+
+            if self.channel_first:
+                out = unpack_one(out, ps, "b * d")
+                out = rearrange(out, "b ... d -> b d ...")
+
+                indices = maybe(unpack_one)(indices, ps, "b * c")
+
+            if not self.keep_num_codebooks_dim and self.return_indices:
+                indices = maybe(rearrange)(indices, "... 1 -> ...")
+
+            # return quantized output and indices
+
+            return out, indices
+
+
+def WNConv1d(*args, **kwargs):
+    return weight_norm(nn.Conv1d(*args, **kwargs))
+
+
+def WNConvTranspose1d(*args, **kwargs):
+    return weight_norm(nn.ConvTranspose1d(*args, **kwargs))
+
+
+# Scripting this brings model speed up 1.4x
+@torch.jit.script
+def snake(x, alpha):
+    shape = x.shape
+    x = x.reshape(shape[0], shape[1], -1)
+    x = x + (alpha + 1e-9).reciprocal() * torch.sin(alpha * x).pow(2)
+    x = x.reshape(shape)
+    return x
+
+
+class Snake1d(nn.Module):
+    def __init__(self, channels):
+        super().__init__()
+        self.alpha = nn.Parameter(torch.ones(1, channels, 1))
+
+    def forward(self, x):
+        return snake(x, self.alpha)
+
+
+def init_weights(m):
+    if isinstance(m, nn.Conv1d):
+        nn.init.trunc_normal_(m.weight, std=0.02)
+        nn.init.constant_(m.bias, 0)
+
+
+class ResidualUnit(nn.Module):
+    def __init__(self, dim: int = 16, dilation: int = 1):
+        super().__init__()
+        pad = ((7 - 1) * dilation) // 2
+        self.block = nn.Sequential(
+            Snake1d(dim),
+            WNConv1d(dim, dim, kernel_size=7, dilation=dilation, padding=pad),
+            Snake1d(dim),
+            WNConv1d(dim, dim, kernel_size=1),
+        )
+
+    def forward(self, x):
+        y = self.block(x)
+        pad = (x.shape[-1] - y.shape[-1]) // 2
+        if pad > 0:
+            x = x[..., pad:-pad]
+        return x + y
+
+
+class EncoderBlock(nn.Module):
+    def __init__(self, dim: int = 16, stride: int = 1):
+        super().__init__()
+        self.block = nn.Sequential(
+            ResidualUnit(dim // 2, dilation=1),
+            ResidualUnit(dim // 2, dilation=3),
+            ResidualUnit(dim // 2, dilation=9),
+            Snake1d(dim // 2),
+            WNConv1d(
+                dim // 2,
+                dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Encoder(nn.Module):
+    def __init__(
+        self,
+        d_model: int = 64,
+        strides: list = [2, 4, 8, 8],
+        d_latent: int = 64,
+    ):
+        super().__init__()
+        # Create first convolution
+        self.block = [WNConv1d(1, d_model, kernel_size=7, padding=3)]
+
+        # Create EncoderBlocks that double channels as they downsample by `stride`
+        for stride in strides:
+            d_model *= 2
+            self.block += [EncoderBlock(d_model, stride=stride)]
+
+        # Create last convolution
+        self.block += [
+            Snake1d(d_model),
+            WNConv1d(d_model, d_latent, kernel_size=3, padding=1),
+        ]
+
+        # Wrap black into nn.Sequential
+        self.block = nn.Sequential(*self.block)
+        self.enc_dim = d_model
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class DecoderBlock(nn.Module):
+    def __init__(self, input_dim: int = 16, output_dim: int = 8, stride: int = 1):
+        super().__init__()
+        self.block = nn.Sequential(
+            Snake1d(input_dim),
+            WNConvTranspose1d(
+                input_dim,
+                output_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+            ResidualUnit(output_dim, dilation=1),
+            ResidualUnit(output_dim, dilation=3),
+            ResidualUnit(output_dim, dilation=9),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        input_channel: int,
+        channels: int,
+        rates: list[int],
+        d_out: int = 1,
+    ):
+        super().__init__()
+
+        # Add first conv layer
+        layers = [WNConv1d(input_channel, channels, kernel_size=7, padding=3)]
+
+        # Add upsampling + MRF blocks
+        for i, stride in enumerate(rates):
+            input_dim = channels // 2**i
+            output_dim = channels // 2 ** (i + 1)
+            layers += [DecoderBlock(input_dim, output_dim, stride)]
+
+        # Add final conv layer
+        layers += [
+            Snake1d(output_dim),
+            WNConv1d(output_dim, d_out, kernel_size=7, padding=3),
+            nn.Tanh(),
+        ]
+
+        self.model = nn.Sequential(*layers)
+
+    # @torch.compile(dynamic=True)
+    def forward(self, z: Tensor):
+        return self.model(z)
+
+
+class FiniteScalarQuantize(nn.Module):
+    def __init__(
+        self, latent_dim: int, levels: list[int], *, stride: int = 1, mlp: bool = False
+    ):
+        super().__init__()
+
+        self.stride = stride
+
+        codebook_dim = len(levels)
+
+        self.in_proj = WNConv1d(latent_dim, codebook_dim, kernel_size=1)
+        self.quantize = FSQ(levels=levels, channel_first=True)
+        self.out_proj = WNConv1d(codebook_dim, latent_dim, kernel_size=1)
+
+        if mlp:
+            self.mlp = nn.Sequential(
+                Rearrange("B C T -> B T C"),
+                nn.Linear(latent_dim, 4 * latent_dim),
+                nn.GELU(),
+                nn.Linear(4 * latent_dim, latent_dim),
+                Rearrange("B T C -> B C T"),
+            )
+        else:
+            self.mlp = None
+
+    def from_indices(self, indices: Tensor):
+        B, T = indices.size()
+        z_q = self.quantize.indices_to_codes(indices)
+        z_q = self.out_proj(z_q)
+        return z_q
+
+    def forward(self, z: Tensor, *args):
+        if self.stride > 1:
+            z = F.avg_pool1d(z, self.stride, stride=self.stride)
+
+        z_e = self.in_proj(z)  # z_e : (B x D x T)
+
+        # we're channels first
+        # scale = scale.unsqueeze(-1)
+
+        # z_e = z_e / scale
+        z_q, indices = self.quantize(z_e)
+        # z_q = z_q * scale
+
+        z_q = self.out_proj(z_q)
+
+        if self.stride > 1:
+            z_e = z_e.repeat_interleave(self.stride, dim=-1)
+            z_q = z_q.repeat_interleave(self.stride, dim=-1)
+            indices = indices.repeat_interleave(self.stride, dim=-1)
+
+        if self.mlp is not None:
+            z_q = self.mlp(z_q)
+
+        return z_q, indices, z_e
+
+
+class ResidualFiniteScalarQuantize(nn.Module):
+    def __init__(
+        self,
+        *,
+        latent_dim: int,
+        n_quantizers: int,
+        levels: list[int],
+        strides: list[int] | None = None,
+        quantizer_dropout: float = 0.0,
+        mlp: bool = False,
+    ):
+        super().__init__()
+
+        self.n_quantizers = n_quantizers
+        self.quantizer_dropout = quantizer_dropout
+
+        strides = [1] * n_quantizers if strides is None else strides
+
+        assert (
+            len(strides) == n_quantizers
+        ), "Strides must be provided for each codebook"
+
+        scales = []
+        quantizers = []
+        levels_tensor = torch.tensor(levels, dtype=torch.float32)
+
+        for i in range(n_quantizers):
+            scales.append((levels_tensor - 1) ** -i)
+            quantizers.append(
+                FiniteScalarQuantize(
+                    latent_dim=latent_dim, levels=levels, stride=strides[i], mlp=mlp
+                )
+            )
+
+        self.quantizers = nn.ModuleList(quantizers)
+
+        self.register_buffer("scales", torch.stack(scales), persistent=False)
+
+        codebooks = [
+            quantizer.quantize.implicit_codebook for quantizer in self.quantizers
+        ]
+        self.codebooks = torch.stack(codebooks, dim=0)
+
+    def from_indices(self, indices: Tensor):
+        B, Q, T = indices.size()
+
+        z_q = 0.0
+
+        for i, quantizer in enumerate(self.quantizers):
+            z_q_i = quantizer.from_indices(indices[:, i])
+            z_q = z_q + z_q_i
+
+        return z_q
+
+    def forward(self, z: Tensor, n_quantizers: int | None = None):
+        """Quantized the input tensor using a fixed set of `n` codebooks and returns
+        the corresponding codebook vectors
+        Parameters
+        ----------
+        z : Tensor[B x D x T]
+        n_quantizers : int, optional
+            No. of quantizers to use
+            (n_quantizers < self.n_codebooks ex: for quantizer dropout)
+            Note: if `self.quantizer_dropout` is True, this argument is ignored
+                when in training mode, and a random number of quantizers is used.
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+
+            "z" : Tensor[B x D x T]
+                Quantized continuous representation of input
+            "codes" : Tensor[B x N x T]
+                Codebook indices for each codebook
+                (quantized discrete representation of input)
+            "latents" : Tensor[B x N*D x T]
+                Projected latents (continuous representation of input before quantization)
+        """
+        B = z.shape[0]
+        z_q = 0
+        residual = z
+
+        indices = []
+        latents = []
+
+        if n_quantizers is None:
+            n_quantizers = self.n_quantizers
+
+        if self.training:
+            n_quantizers = torch.ones((B,)) * self.n_quantizers + 1
+            dropout = torch.randint(1, self.n_quantizers + 1, (B,))
+            n_dropout = int(B * self.quantizer_dropout)
+            n_quantizers[:n_dropout] = dropout[:n_dropout]
+            n_quantizers = n_quantizers.to(z.device)
+
+        for i, quantizer in enumerate(self.quantizers):
+            if not self.training and i >= n_quantizers:
+                break
+
+            z_q_i, indices_i, z_e_i = quantizer(residual)
+
+            residual = residual - z_q_i.detach()
+
+            mask = torch.full((B,), fill_value=i, device=z.device) < n_quantizers
+            z_q = z_q + z_q_i * mask[:, None, None]
+
+            indices.append(indices_i)
+            latents.append(z_e_i)
+
+        indices = torch.stack(indices, dim=1)
+        latents = torch.cat(latents, dim=1)
+
+        return z_q, indices, latents
+
+
+class FluacConfig(BaseModel):
+    sample_rate: int = 44100
+
+    codebook_size: int | None = None
+
+    encoder_dim: int = 64
+    encoder_rates: list[int] = [2, 4, 8, 8]
+
+    quantizer_strides: list[int] | None = None  # SNAC style strides
+    n_quantizers: int = 1
+    fsq_levels: list[int] | None = [8, 5, 5, 5]  # 1000
+    decoder_dim: int = 1536
+    decoder_rates: list[int] = [8, 8, 4, 2]
+
+    @property
+    def hop_length(self) -> int:
+        return math.prod(self.encoder_rates)
+
+    @property
+    def latent_dim(self) -> int:
+        return self.encoder_dim * (2 ** len(self.encoder_rates))
+
+    @property
+    def effective_codebook_size(self) -> int:
+        return math.prod(self.fsq_levels)
+
+
+class Fluac(nn.Module):
+    Q9_22KHZ = "fluac-22hz-22khz.pt"
+
+    def __init__(self, config: FluacConfig):
+        super().__init__()
+
+        self.config = config
+
+        self.encoder = Encoder(
+            config.encoder_dim, config.encoder_rates, config.latent_dim
+        )
+
+        self.quantizer = ResidualFiniteScalarQuantize(
+            latent_dim=config.latent_dim,
+            n_quantizers=config.n_quantizers,
+            levels=config.fsq_levels,
+            strides=config.quantizer_strides,
+        )
+
+        self.decoder = Decoder(
+            config.latent_dim,
+            config.decoder_dim,
+            config.decoder_rates,
+        )
+
+        self.apply(init_weights)
+
+    @staticmethod
+    def from_pretrained(name: str = Q9_22KHZ):
+        if path.exists(name):
+            checkpoint_path = name
+        else:
+            from huggingface_hub import hf_hub_download
+
+            checkpoint_path = hf_hub_download(
+                "fluxions/vui",
+                name,
+            )
+
+        checkpoint = torch.load(checkpoint_path, weights_only=True, map_location="cpu")
+        config = checkpoint["config"]
+        if "model" in config:
+            model_config = FluacConfig(**config["model"])
+        else:
+            model_config = FluacConfig(**config)
+
+        generator = Fluac(model_config).eval()
+        ckpt = decompile_state_dict(checkpoint["generator"])
+        generator.load_state_dict(ckpt)
+        return generator
+
+    def pad(self, waveform: Tensor):
+        T = waveform.size(-1)
+        right_pad = math.ceil(T / self.config.hop_length) * self.config.hop_length - T
+        waveform = F.pad(waveform, (0, right_pad))
+        return waveform
+
+    @torch.inference_mode()
+    def from_indices(self, indices: Tensor):
+        z_q = self.quantizer.from_indices(indices)
+        waveform = self.decoder(z_q)
+        return waveform
+
+    @torch.inference_mode()
+    def encode(self, waveforms: Tensor, n_quantizers: int | None = None):
+        # Ensure that waveforms is 3 dima
+        waveforms = waveforms.flatten()[None][None]
+        waveforms = self.pad(waveforms)
+        B, C, T = waveforms.size()
+        z = self.encoder(waveforms)
+        z_q, codes, latents = self.quantizer(z, n_quantizers=n_quantizers)
+        return codes
+
+    def forward(self, waveforms: Tensor, n_quantizers: int | None = None):
+        B, C, T = waveforms.size()
+        waveforms = self.pad(waveforms)
+        z = self.encoder(waveforms)
+        z_q, codes, latents = self.quantizer(z, n_quantizers=n_quantizers)
+
+        recons = self.decoder(z_q)
+        recons = recons[..., :T]
+        return {
+            "recons": recons,
+            "codes": codes,
+        }
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    @property
+    def dtype(self):
+        return next(self.parameters()).dtype
+
+    @property
+    def hz(self):
+        import numpy as np
+
+        return self.config.sample_rate / np.prod(self.config.encoder_rates).item()
+
+
+if __name__ == "__main__":
+    codec = Fluac.from_pretrained(Fluac.Q9_22KHZ)
+    print(codec.config)
+    wav = torch.rand(1, 1, 22050)
+    wav = codec.pad(wav)
+    codes = codec.encode(wav)
+    breakpoint()

--- a/src/vui/legacy/inference.py
+++ b/src/vui/legacy/inference.py
@@ -1,0 +1,274 @@
+"""Inference for the original-release (pre-1.0) checkpoints.
+
+Ported from the pre-1.0 tree with three changes: device-agnostic autocast
+(bfloat16 on CUDA, model dtype elsewhere — so it runs on Apple Silicon / CPU),
+text cleaning reused from vui.inference, and VAD trimming made optional
+(the old pyannote dependency is gone; without it the full render is returned).
+"""
+
+import time
+
+import torch
+import torch.nn.functional as F
+import torchaudio
+from torch import Tensor
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from vui.inference import remove_all_invalid_non_speech, simple_clean
+from vui.legacy.model import Vui
+from vui.legacy.sampling import (
+    multinomial,
+    sample_top_k,
+    sample_top_p,
+    sample_top_p_top_k,
+)
+
+
+def _autocast():
+    if torch.cuda.is_available():
+        return torch.autocast("cuda", torch.bfloat16, True)
+    from contextlib import nullcontext
+
+    return nullcontext()
+
+
+def _kv_dtype(model: Vui) -> torch.dtype:
+    return torch.bfloat16 if torch.cuda.is_available() else model.dtype
+
+
+def _try_vad(audio_16k: Tensor) -> list:
+    """Old pipeline trimmed with pyannote VAD; treat it as optional."""
+    try:
+        from vui.legacy.vad import detect_voice_activity
+
+        return detect_voice_activity(audio_16k)
+    except ImportError:
+        return []
+
+
+@torch.inference_mode()
+def generate(
+    self: Vui,
+    text: str,
+    prompt_codes: Tensor | None = None,
+    temperature: float = 0.5,
+    top_k: int | None = 150,
+    top_p: float | None = None,
+    max_gen_len: int = int(120 * 21.53),
+    decoder=None,
+):
+    dec = decoder if decoder is not None else self.decoder
+    text = simple_clean(text)
+    if decoder is None and self.device.type == "mps":
+        raise RuntimeError(
+            "The legacy model produces corrupted audio on MPS (and is slower "
+            "than CPU there). Keep it on CPU — already faster than real-time "
+            "— or CUDA."
+        )
+    with _autocast(), sdpa_kernel([SDPBackend.MATH]):
+        t1 = time.perf_counter()
+        batch_size = 1
+        device = self.device
+        dec.allocate_inference_cache(batch_size, device, _kv_dtype(self))
+
+        encoded = self.tokenizer([text], padding="longest", return_tensors="pt")
+        input_ids = encoded.input_ids.to(device)
+        text_embeddings = self.token_emb(input_ids)
+
+        B = batch_size
+        Q = self.config.model.n_quantizers
+
+        if prompt_codes is None:
+            prompt_codes = torch.zeros(
+                (batch_size, Q, 0), dtype=torch.int64, device=device
+            )
+        else:
+            prompt_codes = prompt_codes[:, :Q].repeat(batch_size, 1, 1)
+
+        start_offset = prompt_codes.size(-1)
+
+        pattern = self.pattern_provider.get_pattern(max_gen_len)
+        unknown_token = -1
+        special_token_id = self.config.model.special_token_id
+
+        codes = torch.full(
+            (B, Q, max_gen_len), unknown_token, dtype=torch.int64, device=device
+        )
+        codes[:, :, :start_offset] = prompt_codes
+
+        sequence, indexes, mask = pattern.build_pattern_sequence(
+            codes, special_token_id
+        )
+        start_offset_sequence = pattern.get_first_step_with_timesteps(start_offset)
+        assert start_offset_sequence is not None
+
+        prev_offset = 0
+        S = sequence.size(-1)
+
+        do_prefill = True
+        eos = self.config.model.audio_eos_id
+
+        for offset in range(start_offset_sequence, S):
+            curr_sequence = sequence[..., prev_offset:offset]
+            audio_embeddings = (
+                sum([self.audio_embeddings[q](curr_sequence[:, q]) for q in range(Q)])
+                / Q
+            )
+
+            if do_prefill:
+                embeddings = torch.cat((text_embeddings, audio_embeddings), dim=1)
+                T = embeddings.size(1)
+                input_pos = torch.arange(0, T, device=device)
+                do_prefill = False
+            else:
+                embeddings = audio_embeddings
+                input_pos = torch.tensor([T], device=device)
+                T += 1
+
+            out = dec(embeddings, input_pos)
+
+            if offset == 15:
+                print("TTFB", time.perf_counter() - t1)
+
+            logits = torch.stack(
+                [self.audio_heads[q](out[:, -1]) for q in range(Q)], dim=1
+            )
+
+            repetition_penalty = 1.4
+            history_window = 12
+
+            for q in range(Q):
+                history_start = max(0, offset - history_window)
+                token_history = sequence[0, q, history_start:offset]
+
+                unique_tokens = torch.unique(token_history)
+                unique_tokens = unique_tokens[unique_tokens != special_token_id]
+                unique_tokens = unique_tokens[unique_tokens != eos]
+                unique_tokens = unique_tokens[unique_tokens != unknown_token]
+
+                if len(unique_tokens) > 0:
+                    logits[0, q, unique_tokens] = (
+                        logits[0, q, unique_tokens] / repetition_penalty
+                    )
+
+            if offset < 24.53 * 4:
+                logits[..., eos] = -float("inf")
+
+            probs = F.softmax(logits / temperature, dim=-1)
+
+            if top_p is not None and top_k is not None:
+                next_codes = sample_top_p_top_k(probs, top_p, top_k)
+            elif top_p is not None and top_p > 0:
+                next_codes = sample_top_p(probs, top_p)
+            elif top_k is not None and top_k > 0:
+                next_codes = sample_top_k(probs, top_k)
+            else:
+                next_codes = multinomial(probs, num_samples=1)
+
+            next_codes = next_codes.repeat(batch_size, 1, 1)
+
+            if (probs[..., eos] > 0.95).any():
+                print("breaking at", offset)
+                break
+
+            valid_mask = mask[..., offset : offset + 1].expand(B, -1, -1)
+            next_codes[~valid_mask] = special_token_id
+
+            sequence[..., offset : offset + 1] = torch.where(
+                sequence[..., offset : offset + 1] == unknown_token,
+                next_codes,
+                sequence[..., offset : offset + 1],
+            )
+
+            prev_offset = offset
+
+        out_codes, out_indexes, out_mask = pattern.revert_pattern_sequence(
+            sequence, special_token=unknown_token
+        )
+        out_codes = out_codes[..., prompt_codes.shape[-1] : offset]
+        return out_codes[[0]]
+
+
+@torch.inference_mode()
+def render(
+    self: Vui,
+    text: str,
+    prompt_codes: Tensor | None = None,
+    temperature: float = 0.5,
+    top_k: int | None = 100,
+    top_p: float | None = None,
+    max_secs: int = 100,
+    decoder=None,
+):
+    """Render audio from text. Returns (1, 1, S) float audio at the codec
+    sample rate (22050). Long texts (>1000 chars) are chunked line-by-line
+    with rolling code context, as in the original release."""
+    text = remove_all_invalid_non_speech(text)
+    text = simple_clean(text)
+    SR = self.codec.config.sample_rate
+    HZ = self.codec.hz
+    max_gen_len = int(HZ * max_secs)
+
+    if len(text) < 1000:
+        codes = generate(
+            self, text, prompt_codes, temperature, top_k, top_p, max_gen_len,
+            decoder=decoder,
+        )
+        codes = codes[..., :-10]
+        audio = self.codec.from_indices(codes)
+        paudio = torchaudio.functional.resample(audio[0], SR, 16000)
+        results = _try_vad(paudio)
+        if results:
+            s, e = results[0][0], results[-1][1]
+            return audio[..., int(s * SR) : int((e + 0.2) * SR)].cpu()
+        return audio.cpu()
+
+    lines = text.split("\n")
+    audios = []
+    prev_codes = prompt_codes
+    orig_codes = prompt_codes
+    prev_text = ""
+
+    for line in lines:
+        run = True
+        while run:
+            current_text = prev_text + "\n" + line if prev_text else line
+            current_text = current_text.strip().replace("...", "") + " [pause]"
+            maxlen = int(HZ * int(60 * len(current_text) / 500))
+
+            try:
+                print("rendering", current_text)
+                codes = generate(
+                    self,
+                    current_text,
+                    prompt_codes=prev_codes,
+                    temperature=temperature,
+                    top_k=top_k,
+                    top_p=top_p,
+                    max_gen_len=maxlen,
+                    decoder=decoder,
+                )
+                codes = codes[..., :-10]
+                audio = self.codec.from_indices(codes)
+                paudio = torchaudio.functional.resample(audio[0], SR, 16000)
+                results = _try_vad(paudio)
+                run = False
+
+                if results:
+                    prev_text = line
+                    s, e = results[0][0], results[0][1]
+                    codes = codes[..., int(s * HZ) : int(e * HZ)]
+                    prev_codes = codes
+                    audios.append(audio[..., int(s * SR) : int((e + 0.2) * SR)].cpu())
+                else:
+                    prev_text = line
+                    prev_codes = codes
+                    audios.append(audio.cpu())
+            except KeyboardInterrupt:
+                break
+            except RuntimeError as e:
+                prev_codes = orig_codes
+                prev_text = ""
+                print(e)
+
+    return torch.cat(audios, dim=-1)

--- a/src/vui/legacy/model.py
+++ b/src/vui/legacy/model.py
@@ -1,0 +1,445 @@
+import math
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from torch import Tensor
+from transformers import AutoTokenizer
+
+from vui.legacy.fluac import Fluac
+from vui.model import load_what_you_can
+
+from .config import Config
+from .patterns import DelayedPatternProvider
+from .rope import apply_rotary_emb, precompute_freqs_cis
+
+
+class KVCache(nn.Module):
+    def __init__(
+        self,
+        batch_size: int,
+        max_seqlen: int,
+        n_kv_heads: int,
+        head_dim: int,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+
+        cache_shape = (batch_size, n_kv_heads, max_seqlen, head_dim)
+
+        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+
+    def update(self, input_pos: Tensor, k_val: Tensor, v_val: Tensor):
+        # input_pos: (T,), k_val: (B, nh, T, d)
+        assert input_pos.size(0) == k_val.size(-2)
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out
+
+
+def repeat_kv(x: torch.Tensor, n_reps: int) -> torch.Tensor:
+    """torch.repeat_interleave(x, dim=2, repeats=n_rep)"""
+    bs, n_kv_heads, T, head_dim = x.shape
+
+    return (
+        x[:, :, :, None, :]
+        .expand(bs, n_kv_heads, n_reps, T, head_dim)
+        .reshape(bs, n_kv_heads * n_reps, T, head_dim)
+    )
+
+
+class MHA(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        n_kv_heads: int,
+        *,
+        block_idx: int,
+        bias: bool = False,
+        dropout: float = 0.0,
+        causal: bool = False,
+        use_rotary_emb: bool = True,
+    ):
+        super().__init__()
+
+        head_dim = dim // n_heads
+
+        self.use_rotary_emb = use_rotary_emb
+        self.block_idx = block_idx
+        self.dim = dim
+        self.n_heads = n_heads
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = head_dim
+        self.dropout = dropout
+        self.causal = causal
+        self.n_reps = n_kv_heads // n_heads
+        qkv_dim = (n_heads + 2 * n_kv_heads) * head_dim
+        self.Wqkv = nn.Linear(dim, qkv_dim, bias=bias)
+        self.out_proj = nn.Linear(dim, dim, bias=bias)
+        self.kv_cache = None
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor | None = None,
+        input_pos: Tensor | None = None,
+        attn_mask: Tensor | None = None,
+    ):
+        B, T, d = x.size()
+        x.dtype
+
+        dropout_p = self.dropout if self.training else 0.0
+
+        qkv = self.Wqkv(x)
+        if self.n_heads == self.n_kv_heads:
+            qkv = rearrange(
+                qkv, "B T (three h d) -> B three h T d", three=3, h=self.n_heads
+            )
+            q, k, v = qkv.unbind(dim=1)  # (B, h, T, d)
+        else:
+            q, k, v = torch.split(
+                qkv,
+                [
+                    self.head_dim * self.n_heads,
+                    self.head_dim * self.n_kv_heads,
+                    self.head_dim * self.n_kv_heads,
+                ],
+                dim=1,
+            )
+            q, k, v = map(lambda t: rearrange(t, "B T (h d) -> B h T d"), (q, k, v))
+
+        if self.use_rotary_emb:
+            q = apply_rotary_emb(freqs_cis, q)
+            k = apply_rotary_emb(freqs_cis, k)
+
+        if self.kv_cache is not None:
+            k, v = self.kv_cache.update(input_pos, k, v)
+
+        if self.n_reps > 1:
+            k = repeat_kv(k, self.n_reps)
+            v = repeat_kv(v, self.n_reps)
+
+        is_causal = self.causal and self.kv_cache is None
+
+        out = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            dropout_p=dropout_p,
+            is_causal=is_causal,
+            attn_mask=attn_mask,
+        )
+
+        out = self.out_proj(rearrange(out, "B h T d -> B T (h d)"))
+
+        return out
+
+
+class MLP(nn.Module):
+    def __init__(
+        self, *, d_model: int, bias: bool, dropout: float, act=nn.GELU, **kwargs
+    ):
+        super().__init__()
+        self.fc1 = nn.Linear(d_model, 4 * d_model, bias=bias)
+        self.act = act()
+        self.fc2 = nn.Linear(4 * d_model, d_model, bias=bias)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x):
+        return self.dropout(self.fc2(self.act(self.fc1(x))))
+
+
+class LlamaMLP(nn.Module):
+    def __init__(
+        self, *, d_model: int, multiple_of: int = 256, bias: bool = False, **kwargs
+    ) -> None:
+        super().__init__()
+        hidden_dim = 4 * d_model
+        hidden_dim = int(2 * hidden_dim / 3)
+        hidden_dim = multiple_of * ((hidden_dim + multiple_of - 1) // multiple_of)
+        self.w1 = nn.Linear(d_model, hidden_dim, bias=bias)
+        self.w3 = nn.Linear(d_model, hidden_dim, bias=bias)
+        self.w2 = nn.Linear(hidden_dim, d_model, bias=bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor):
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        *,
+        d_model: int,
+        n_heads: int,
+        n_kv_heads: int,
+        block_idx: int,
+        bias: bool,
+        dropout: float,
+        norm_eps: float = 1e-5,  # use 1e-6 for rms
+        use_rotary_emb: bool = True,
+    ):
+        super().__init__()
+
+        self.block_idx = block_idx
+        self.n_heads = n_heads
+        self.n_kv_heads = n_kv_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model, eps=norm_eps)
+        self.attn = MHA(
+            d_model,
+            n_heads,
+            n_kv_heads,
+            block_idx=block_idx,
+            bias=bias,
+            dropout=dropout,
+            causal=True,
+            use_rotary_emb=use_rotary_emb,
+        )
+        self.mlp_norm = RMSNorm(d_model, eps=norm_eps)
+        self.mlp = LlamaMLP(d_model=d_model, bias=bias, dropout=dropout)
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor | None = None,
+        input_pos: Tensor | None = None,
+        attn_mask: Tensor | None = None,
+    ):
+        x = x + self.attn(
+            self.attn_norm(x),
+            freqs_cis=freqs_cis,
+            input_pos=input_pos,
+            attn_mask=attn_mask,
+        )
+        x = x + self.mlp(self.mlp_norm(x))
+
+        return x
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        *,
+        n_layers: int,
+        d_model: int,
+        n_heads: int,
+        n_kv_heads: int,
+        bias: bool,
+        dropout: float,
+        max_seqlen: int = 4096,
+        rope_theta: float = 10000.0,
+        rope_theta_rescale_factor: float = 1.0,
+        norm_eps: float = 1e-5,
+        use_rotary_emb: bool = True,
+        rope_dim: int | None = None,
+    ):
+        super().__init__()
+        assert d_model % n_heads == 0
+
+        self.use_rotary_emb = use_rotary_emb
+
+        self.max_seqlen = max_seqlen
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    d_model=d_model,
+                    n_heads=n_heads,
+                    n_kv_heads=n_kv_heads,
+                    block_idx=block_idx,
+                    bias=bias,
+                    dropout=dropout,
+                    norm_eps=norm_eps,
+                    use_rotary_emb=use_rotary_emb,
+                )
+                for block_idx in range(n_layers)
+            ]
+        )
+        self.norm = RMSNorm(d_model, eps=norm_eps)
+
+        self.attn_mask = None
+
+        head_dim = d_model // n_heads
+
+        rope_dim = rope_dim or head_dim
+
+        assert rope_dim <= head_dim  # apply RoPE to a fraction of embeddings
+
+        freqs_cis = precompute_freqs_cis(
+            rope_dim,
+            max_seqlen,
+            theta=rope_theta,
+            theta_rescale_factor=rope_theta_rescale_factor,
+        )
+        self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+
+    def allocate_inference_cache(
+        self, batch_size: int, device: str, dtype=torch.bfloat16
+    ):
+        for block in self.blocks:
+            block.attn.kv_cache = KVCache(
+                batch_size, self.max_seqlen, block.n_kv_heads, block.head_dim, dtype
+            ).to(device)
+
+        # I don't understand why this is needed
+        self.attn_mask = torch.tril(
+            torch.ones(
+                self.max_seqlen, self.max_seqlen, dtype=torch.bool, device=device
+            )
+        )
+
+    def deallocate_kv_cache(self):
+        for block in self.blocks:
+            block.attn.kv_cache = None
+
+        self.attn_mask = None
+
+    def forward(self, x: Tensor, input_pos: Tensor):
+        if self.use_rotary_emb:
+            freqs_cis = self.freqs_cis[input_pos]
+        else:
+            freqs_cis = None
+
+        attn_mask = (
+            self.attn_mask[None, None, input_pos]
+            if self.attn_mask is not None
+            else None
+        )
+
+        for block in self.blocks:
+            x = block(x, freqs_cis=freqs_cis, input_pos=input_pos, attn_mask=attn_mask)
+
+        x = self.norm(x)
+
+        return x
+
+
+class Vui(nn.Module):
+    BASE = "vui-100m-base.pt"
+    COHOST = "vui-cohost-100m.pt"
+    ABRAHAM = "vui-abraham-100m.pt"
+
+    def __init__(self, config: Config = Config()):
+        super().__init__()
+        self.codec = Fluac.from_pretrained()
+        self.config = config
+        cfg = config.model
+        self.tokenizer = AutoTokenizer.from_pretrained("google/byt5-small")
+        self.use_rotary_emb = cfg.use_rotary_emb
+        self.token_emb = nn.Embedding(self.tokenizer.vocab_size, cfg.d_model)
+
+        self.pattern_provider = DelayedPatternProvider(n_q=cfg.n_quantizers)
+
+        self.audio_embeddings = nn.ModuleList(
+            [
+                nn.Embedding(cfg.codebook_size + 8, cfg.d_model)
+                for _ in range(cfg.n_quantizers)
+            ]
+        )
+
+        n_kv_heads = cfg.n_heads
+
+        max_seqlen = cfg.max_text_tokens + cfg.max_audio_tokens
+        self.decoder = Decoder(
+            n_layers=cfg.n_layers,
+            d_model=cfg.d_model,
+            n_heads=cfg.n_heads,
+            n_kv_heads=n_kv_heads,
+            bias=cfg.bias,
+            dropout=cfg.dropout,
+            max_seqlen=max_seqlen + cfg.n_quantizers,
+            rope_dim=cfg.rope_dim,
+            rope_theta=cfg.rope_theta,
+            rope_theta_rescale_factor=cfg.rope_theta_rescale_factor,
+        )
+
+        self.audio_heads = nn.ModuleList(
+            [
+                nn.Linear(cfg.d_model, cfg.codebook_size + 8, bias=cfg.bias)
+                for _ in range(cfg.n_quantizers)
+            ]
+        )
+
+        self.apply(self._init_weights)
+
+        for pn, p in self.named_parameters():
+            if pn.endswith("out_proj.weight"):
+                torch.nn.init.normal_(
+                    p, mean=0.0, std=0.02 / math.sqrt(2 * cfg.n_layers)
+                )
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                torch.nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+
+    @staticmethod
+    def from_pretrained(
+        checkpoint_path: str | dict = ABRAHAM,
+        **config_kwargs,
+    ):
+        if isinstance(checkpoint_path, dict):
+            checkpoint = checkpoint_path
+        else:
+            if not os.path.exists(checkpoint_path):
+                from huggingface_hub import hf_hub_download
+
+                checkpoint_path = hf_hub_download(
+                    "fluxions/vui",
+                    checkpoint_path,
+                )
+            checkpoint = torch.load(
+                checkpoint_path, map_location="cpu", weights_only=True
+            )
+
+        config = {**checkpoint["config"], **config_kwargs}
+        config = Config(**config)
+        state_dict = checkpoint["model"]
+
+        state_dict = {k.replace("module.", ""): v for k, v in state_dict.items()}
+        state_dict = {
+            k.replace("text_embedding.", "token_emb."): v for k, v in state_dict.items()
+        }
+        model = Vui(config)
+        load_what_you_can(state_dict, model)
+        return model
+
+    @staticmethod
+    def from_pretrained_inf(
+        checkpoint_path: str | dict,
+        **config_kwargs,
+    ):
+        return Vui.from_pretrained(checkpoint_path, **config_kwargs).eval()
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    @property
+    def dtype(self):
+        return next(self.parameters()).dtype

--- a/src/vui/legacy/patterns.py
+++ b/src/vui/legacy/patterns.py
@@ -1,0 +1,423 @@
+import logging
+from abc import ABC, abstractmethod
+from collections import namedtuple
+from dataclasses import dataclass
+from functools import lru_cache
+
+import torch
+import torch.nn.functional as F
+
+
+def apply_delay_pattern(codes: torch.Tensor, mask_token: int):
+    codes = F.pad(codes, (0, codes.shape[1] + 1), value=mask_token)
+    return torch.stack([codes[:, k].roll(k + 1) for k in range(codes.shape[1])], dim=1)
+
+
+def revert_delay_pattern(codes: torch.Tensor):
+    _, n_q, seq_len = codes.shape
+    return torch.stack(
+        [codes[:, k, k + 1 : seq_len - n_q + k] for k in range(n_q)], dim=1
+    )
+
+
+LayoutCoord = namedtuple("LayoutCoord", ["t", "q"])  # (timestep, codebook index)
+PatternLayout = list[list[LayoutCoord]]  # Sequence of coordinates
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Pattern:
+    """Base implementation of a pattern over a sequence with multiple codebooks.
+
+    The codebook pattern consists in a layout, defining for each sequence step
+    the list of coordinates of each codebook timestep in the resulting interleaved sequence.
+    The first item of the pattern is always an empty list in order to properly insert a special token
+    to start with. For convenience, we also keep track of ``n_q`` the number of codebooks used for the pattern
+    and ``timesteps`` the number of timesteps corresponding to the original sequence.
+
+    The pattern provides convenient methods to build and revert interleaved sequences from it:
+    ``build_pattern_sequence`` maps a given a dense input tensor of multi-codebook sequence from [B, K, T]
+        to the interleaved sequence of shape [B, K, S] applying the pattern, with B being the batch size,
+        K being the number of codebooks, T the number of original timesteps and S the number of sequence steps
+        for the output sequence. The unfilled positions are replaced with a special token and the built sequence
+        is returned along with a mask indicating valid tokens.
+    ``revert_pattern_sequence`` maps back an interleaved sequence of shape [B, K, S] to the original alignment
+        of codebooks across timesteps to an output tensor of shape [B, K, T], using again a special token and a mask
+        to fill and specify invalid positions if needed.
+    See the dedicated methods for more details.
+    """
+
+    # Pattern layout, for each sequence step, we have a list of coordinates
+    # corresponding to the original codebook timestep and position.
+    # The first list is always an empty list in order to properly insert
+    # a special token to start with.
+    layout: PatternLayout
+    timesteps: int
+    n_q: int
+
+    def __post_init__(self):
+        assert len(self.layout) > 0
+        self._validate_layout()
+        self._build_reverted_sequence_scatter_indexes = lru_cache(100)(
+            self._build_reverted_sequence_scatter_indexes
+        )
+        self._build_pattern_sequence_scatter_indexes = lru_cache(100)(
+            self._build_pattern_sequence_scatter_indexes
+        )
+        logger.info(
+            "New pattern, time steps: %d, sequence steps: %d",
+            self.timesteps,
+            len(self.layout),
+        )
+
+    def _validate_layout(self):
+        """Runs checks on the layout to ensure a valid pattern is defined.
+        A pattern is considered invalid if:
+            - Multiple timesteps for a same codebook are defined in the same sequence step
+            - The timesteps for a given codebook are not in ascending order as we advance in the sequence
+              (this would mean that we have future timesteps before past timesteps).
+        """
+        q_timesteps = {q: 0 for q in range(self.n_q)}
+        for s, seq_coords in enumerate(self.layout):
+            if len(seq_coords) > 0:
+                qs = set()
+                for coord in seq_coords:
+                    qs.add(coord.q)
+                    last_q_timestep = q_timesteps[coord.q]
+                    assert (
+                        coord.t >= last_q_timestep
+                    ), f"Past timesteps are found in the sequence for codebook = {coord.q} at step {s}"
+                    q_timesteps[coord.q] = coord.t
+                # each sequence step contains at max 1 coordinate per codebook
+                assert len(qs) == len(
+                    seq_coords
+                ), f"Multiple entries for a same codebook are found at step {s}"
+
+    @property
+    def num_sequence_steps(self):
+        return len(self.layout) - 1
+
+    @property
+    def max_delay(self):
+        max_t_in_seq_coords = 0
+        for seq_coords in self.layout[1:]:
+            for coords in seq_coords:
+                max_t_in_seq_coords = max(max_t_in_seq_coords, coords.t + 1)
+        return max_t_in_seq_coords - self.timesteps
+
+    @property
+    def valid_layout(self):
+        valid_step = len(self.layout) - self.max_delay
+        return self.layout[:valid_step]
+
+    def starts_with_special_token(self):
+        return self.layout[0] == []
+
+    def get_sequence_coords_with_timestep(self, t: int, q: int | None = None):
+        """Get codebook coordinates in the layout that corresponds to the specified timestep t
+        and optionally to the codebook q. Coordinates are returned as a tuple with the sequence step
+        and the actual codebook coordinates.
+        """
+        assert (
+            t <= self.timesteps
+        ), "provided timesteps is greater than the pattern's number of timesteps"
+        if q is not None:
+            assert (
+                q <= self.n_q
+            ), "provided number of codebooks is greater than the pattern's number of codebooks"
+        coords = []
+        for s, seq_codes in enumerate(self.layout):
+            for code in seq_codes:
+                if code.t == t and (q is None or code.q == q):
+                    coords.append((s, code))
+        return coords
+
+    def get_steps_with_timestep(self, t: int, q: int | None = None) -> list[int]:
+        return [step for step, coords in self.get_sequence_coords_with_timestep(t, q)]
+
+    def get_first_step_with_timesteps(self, t: int, q: int | None = None) -> int | None:
+        steps_with_timesteps = self.get_steps_with_timestep(t, q)
+        return steps_with_timesteps[0] if len(steps_with_timesteps) > 0 else None
+
+    def _build_pattern_sequence_scatter_indexes(
+        self,
+        timesteps: int,
+        n_q: int,
+        keep_only_valid_steps: bool,
+        device: torch.device | str = "cpu",
+    ):
+        """Build scatter indexes corresponding to the pattern, up to the provided sequence_steps.
+
+        Args:
+            timesteps (int): Maximum number of timesteps steps to consider.
+            keep_only_valid_steps (bool): Restrict the pattern layout to match only valid steps.
+            device (torch.device or str): Device for created tensors.
+        Returns:
+            indexes (torch.Tensor): Indexes corresponding to the sequence, of shape [K, S].
+            mask (torch.Tensor): Mask corresponding to indexes that matches valid indexes, of shape [K, S].
+        """
+        assert (
+            n_q == self.n_q
+        ), f"invalid number of codebooks for the sequence and the pattern: {n_q} != {self.n_q}"
+        assert (
+            timesteps <= self.timesteps
+        ), "invalid number of timesteps used to build the sequence from the pattern"
+        # use the proper layout based on whether we limit ourselves to valid steps only or not,
+        # note that using the valid_layout will result in a truncated sequence up to the valid steps
+        ref_layout = self.valid_layout if keep_only_valid_steps else self.layout
+        # single item indexing being super slow with pytorch vs. numpy, so we use numpy here
+        indexes = torch.zeros(n_q, len(ref_layout), dtype=torch.long).numpy()
+        mask = torch.zeros(n_q, len(ref_layout), dtype=torch.bool).numpy()
+        # fill indexes with last sequence step value that will correspond to our special token
+        # the last value is n_q * timesteps as we have flattened z and append special token as the last token
+        # which will correspond to the index: n_q * timesteps
+        indexes[:] = n_q * timesteps
+        # iterate over the pattern and fill scattered indexes and mask
+        for s, sequence_coords in enumerate(ref_layout):
+            for coords in sequence_coords:
+                if coords.t < timesteps:
+                    indexes[coords.q, s] = coords.t + coords.q * timesteps
+                    mask[coords.q, s] = 1
+        indexes = torch.from_numpy(indexes).to(device)
+        mask = torch.from_numpy(mask).to(device)
+        return indexes, mask
+
+    def build_pattern_sequence(
+        self, z: torch.Tensor, special_token: int, keep_only_valid_steps: bool = False
+    ):
+        """Build sequence corresponding to the pattern from the input tensor z.
+        The sequence is built using up to sequence_steps if specified, and non-pattern
+        coordinates are filled with the special token.
+
+        Args:
+            z (torch.Tensor): Input tensor of multi-codebooks sequence, of shape [B, K, T].
+            special_token (int): Special token used to fill non-pattern coordinates in the new sequence.
+            keep_only_valid_steps (bool): Build a sequence from the pattern up to valid (= fully defined) steps.
+                Steps that are beyond valid steps will be replaced by the special_token in that case.
+        Returns:
+            values (torch.Tensor): Interleaved sequence matching the pattern, of shape [B, K, S] with S
+                corresponding either to the sequence_steps if provided, otherwise to the length of the pattern.
+            indexes (torch.Tensor): Indexes corresponding to the interleaved sequence, of shape [K, S].
+            mask (torch.Tensor): Mask corresponding to indexes that matches valid indexes of shape [K, S].
+        """
+        B, K, T = z.shape
+        indexes, mask = self._build_pattern_sequence_scatter_indexes(
+            T, K, keep_only_valid_steps=keep_only_valid_steps, device=str(z.device)
+        )
+        z = z.reshape(B, -1)
+        # we append the special token as the last index of our flattened z tensor
+        z = torch.cat([z, torch.zeros_like(z[:, :1]) + special_token], dim=1)
+        values = z[:, indexes.view(-1)]
+        values = values.view(B, K, indexes.shape[-1])
+        return values, indexes, mask
+
+    def _build_reverted_sequence_scatter_indexes(
+        self,
+        sequence_steps: int,
+        n_q: int,
+        keep_only_valid_steps: bool = False,
+        is_model_output: bool = False,
+        device: torch.device | str = "cpu",
+    ):
+        """Builds scatter indexes required to retrieve the original multi-codebook sequence
+        from interleaving pattern.
+
+        Args:
+            sequence_steps (int): Sequence steps.
+            n_q (int): Number of codebooks.
+            keep_only_valid_steps (bool): Build a sequence from the pattern up to valid (= fully defined) steps.
+                Steps that are beyond valid steps will be replaced by the special_token in that case.
+            is_model_output (bool): Whether to keep the sequence item corresponding to initial special token or not.
+            device (torch.device or str): Device for created tensors.
+        Returns:
+            indexes (torch.Tensor): Indexes for reconstructing the output, of shape [K, T].
+            mask (torch.Tensor): Mask corresponding to indexes that matches valid indexes of shape [K, T].
+        """
+        ref_layout = self.valid_layout if keep_only_valid_steps else self.layout
+        timesteps = self.timesteps
+        assert (
+            n_q == self.n_q
+        ), f"invalid number of codebooks for the sequence and the pattern: {n_q} != {self.n_q}"
+        assert sequence_steps <= len(
+            ref_layout
+        ), f"sequence to revert is longer than the defined pattern: {sequence_steps} > {len(ref_layout)}"
+
+        # ensure we take the appropriate indexes to keep the model output from the first special token as well
+        if is_model_output and self.starts_with_special_token():
+            ref_layout = ref_layout[1:]
+
+        # single item indexing being super slow with pytorch vs. numpy, so we use numpy here
+        indexes = torch.zeros(n_q, timesteps, dtype=torch.long).numpy()
+        mask = torch.zeros(n_q, timesteps, dtype=torch.bool).numpy()
+        # fill indexes with last sequence step value that will correspond to our special token
+        indexes[:] = n_q * sequence_steps
+        for s, sequence_codes in enumerate(ref_layout):
+            if s < sequence_steps:
+                for code in sequence_codes:
+                    if code.t < timesteps:
+                        indexes[code.q, code.t] = s + code.q * sequence_steps
+                        mask[code.q, code.t] = 1
+        indexes = torch.from_numpy(indexes).to(device)
+        mask = torch.from_numpy(mask).to(device)
+        return indexes, mask
+
+    def revert_pattern_sequence(
+        self, s: torch.Tensor, special_token: int, keep_only_valid_steps: bool = False
+    ):
+        """Revert a sequence built from the pattern back to the original multi-codebook sequence without interleaving.
+        The sequence is reverted using up to timesteps if specified, and non-pattern coordinates
+        are filled with the special token.
+
+        Args:
+            s (torch.Tensor): Interleaved sequence tensor obtained from the pattern, of shape [B, K, S].
+            special_token (int or float): Special token used to fill non-pattern coordinates in the new sequence.
+        Returns:
+            values (torch.Tensor): Interleaved sequence matching the pattern, of shape [B, K, T] with T
+                corresponding either to the timesteps if provided, or the total timesteps in pattern otherwise.
+            indexes (torch.Tensor): Indexes corresponding to the interleaved sequence, of shape [K, T].
+            mask (torch.Tensor): Mask corresponding to indexes that matches valid indexes of shape [K, T].
+        """
+        B, K, S = s.shape
+        indexes, mask = self._build_reverted_sequence_scatter_indexes(
+            S, K, keep_only_valid_steps, is_model_output=False, device=str(s.device)
+        )
+        s = s.view(B, -1)
+        # we append the special token as the last index of our flattened z tensor
+        s = torch.cat([s, torch.zeros_like(s[:, :1]) + special_token], dim=1)
+        values = s[:, indexes.view(-1)]
+        values = values.view(B, K, indexes.shape[-1])
+        return values, indexes, mask
+
+    def revert_pattern_logits(
+        self,
+        logits: torch.Tensor,
+        special_token: float,
+        keep_only_valid_steps: bool = False,
+    ):
+        """Revert model logits obtained on a sequence built from the pattern
+        back to a tensor matching the original sequence.
+
+        This method is similar to ``revert_pattern_sequence`` with the following specificities:
+        1. It is designed to work with the extra cardinality dimension
+        2. We return the logits for the first sequence item that matches the special_token and
+        which matching target in the original sequence is the first item of the sequence,
+        while we skip the last logits as there is no matching target
+        """
+        B, n, Q, S = logits.shape
+        indexes, mask = self._build_reverted_sequence_scatter_indexes(
+            S, Q, keep_only_valid_steps, is_model_output=True, device=logits.device
+        )
+        logits = logits.reshape(B, n, -1)
+        # we append the special token as the last index of our flattened z tensor
+        logits = torch.cat(
+            [logits, torch.zeros_like(logits[:, :, :1]) + special_token], dim=-1
+        )  # [B, card, K x S]
+        values = logits[:, :, indexes.view(-1)]
+        values = values.view(B, n, Q, indexes.shape[-1])
+        return values, indexes, mask
+
+
+class CodebooksPatternProvider(ABC):
+    """Abstraction around providing pattern for interleaving codebooks.
+
+    The CodebooksPatternProvider abstraction allows to implement various strategies to
+    define interleaving pattern of sequences composed of multiple codebooks. For a given
+    number of codebooks `n_q`, the pattern provider can generate a specified pattern
+    corresponding to a sequence of `T` timesteps with `n_q` parallel codebooks. This pattern
+    can be used to construct a new sequence from the original codes respecting the specified
+    pattern. The pattern is defined as a list of list of code coordinates, code coordinate
+    being a tuple with the original timestep and codebook to build the new sequence.
+    Note that all patterns must start with an empty list that is then used to insert a first
+    sequence step of special tokens in the newly generated sequence.
+
+    Args:
+        n_q (int): number of codebooks.
+        cached (bool): if True, patterns for a given length are cached. In general
+            that should be true for efficiency reason to avoid synchronization points.
+    """
+
+    def __init__(self, n_q: int, cached: bool = True):
+        assert n_q > 0
+        self.n_q = n_q
+        self.get_pattern = lru_cache(100)(self.get_pattern)  # type: ignore
+
+    @abstractmethod
+    def get_pattern(self, timesteps: int) -> Pattern:
+        """Builds pattern with specific interleaving between codebooks.
+
+        Args:
+            timesteps (int): Total number of timesteps.
+        """
+        raise NotImplementedError()
+
+
+class DelayedPatternProvider(CodebooksPatternProvider):
+    """Provider for delayed pattern across delayed codebooks.
+    Codebooks are delayed in the sequence and sequence steps will contain codebooks
+    from different timesteps.
+
+    Example:
+        Taking timesteps=4 and n_q=3, delays=None, the multi-codebook sequence:
+        [[1, 2, 3, 4],
+        [1, 2, 3, 4],
+        [1, 2, 3, 4]]
+        The resulting sequence obtained from the returned pattern is:
+        [[S, 1, 2, 3, 4],
+        [S, S, 1, 2, 3],
+        [S, S, S, 1, 2]]
+        (with S being a special token)
+
+    Args:
+        n_q (int): Number of codebooks.
+        delays (list of int, optional): Delay for each of the codebooks.
+            If delays not defined, each codebook is delayed by 1 compared to the previous one.
+        flatten_first (int): Flatten the first N timesteps.
+        empty_initial (int): Prepend with N empty list of coordinates.
+    """
+
+    def __init__(
+        self,
+        n_q: int,
+        delays: list[int] | None = None,
+        flatten_first: int = 0,
+        empty_initial: int = 0,
+    ):
+        super().__init__(n_q)
+        if delays is None:
+            delays = list(range(n_q))
+        self.delays = delays
+        self.flatten_first = flatten_first
+        self.empty_initial = empty_initial
+        assert len(self.delays) == self.n_q
+        assert sorted(self.delays) == self.delays
+
+    def get_pattern(self, timesteps: int) -> Pattern:
+        omit_special_token = self.empty_initial < 0
+        out: PatternLayout = [] if omit_special_token else [[]]
+        max_delay = max(self.delays)
+        if self.empty_initial:
+            out += [[] for _ in range(self.empty_initial)]
+        if self.flatten_first:
+            for t in range(min(timesteps, self.flatten_first)):
+                for q in range(self.n_q):
+                    out.append([LayoutCoord(t, q)])
+        for t in range(self.flatten_first, timesteps + max_delay):
+            v = []
+            for q, delay in enumerate(self.delays):
+                t_for_q = t - delay
+                if t_for_q >= self.flatten_first:
+                    v.append(LayoutCoord(t_for_q, q))
+            out.append(v)
+        return Pattern(out, n_q=self.n_q, timesteps=timesteps)
+
+
+if __name__ == "__main__":
+    # Tried to use the simple patterns to train and something very odd happened.
+    Q = 4
+
+    codes = torch.randint(0, 1000, (1, Q, 100))
+    pcodes = apply_delay_pattern(codes, 1001)
+    provider = DelayedPatternProvider(Q)
+    provider = provider.get_pattern(100)
+    pcodes2 = provider.build_pattern_sequence(codes, 1001)
+    breakpoint()

--- a/src/vui/legacy/rope.py
+++ b/src/vui/legacy/rope.py
@@ -1,0 +1,54 @@
+import torch
+from einops import rearrange, repeat
+from torch import Tensor
+from torch.amp import autocast
+
+
+def rotate_half(x):
+    """Also known as "interleaved" style or GPT-J style."""
+    x = rearrange(x, "... (d r) -> ... d r", r=2)
+    x1, x2 = x.unbind(dim=-1)
+    x = torch.stack((-x2, x1), dim=-1)
+    return rearrange(x, "... d r -> ... (d r)")
+
+
+@autocast("cuda", enabled=False)
+def apply_rotary_emb(
+    freqs: Tensor, t: Tensor, start_index: int = 0, scale: float = 1.0, seq_dim=-2
+):
+    dtype = t.dtype
+
+    if t.ndim == 3:
+        seq_len = t.shape[seq_dim]
+        freqs = freqs[-seq_len:]
+
+    rot_dim = freqs.shape[-1]
+    end_index = start_index + rot_dim
+
+    assert (
+        rot_dim <= t.shape[-1]
+    ), f"feature dimension {t.shape[-1]} is not of sufficient size to rotate in all the positions {rot_dim}"
+
+    t_left, t, t_right = (
+        t[..., :start_index],
+        t[..., start_index:end_index],
+        t[..., end_index:],
+    )
+    t = (t * freqs.cos() * scale) + (rotate_half(t) * freqs.sin() * scale)
+    out = torch.cat((t_left, t, t_right), dim=-1)
+    return out.to(dtype)
+
+
+def precompute_freqs_cis(
+    dim: int,
+    max_seqlen: int,
+    theta: float = 10_000.0,
+    theta_rescale_factor: float = 1.0,
+    dtype: torch.dtype = torch.float32,
+):
+    theta *= theta_rescale_factor ** (dim / (dim - 2))
+    pos = torch.arange(max_seqlen, dtype=dtype)
+    inv_freqs = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=dtype) / dim))
+    freqs = torch.einsum("..., f -> ... f", pos.to(inv_freqs.dtype), inv_freqs)
+    freqs = repeat(freqs, "... n -> ... (n r)", r=2)
+    return freqs

--- a/src/vui/legacy/sampling.py
+++ b/src/vui/legacy/sampling.py
@@ -1,0 +1,43 @@
+import torch
+from torch import Tensor
+
+
+def multinomial(input: Tensor, num_samples: int, replacement=False, *, generator=None):
+    input_ = input.reshape(-1, input.shape[-1])
+    output_ = torch.multinomial(
+        input_, num_samples=num_samples, replacement=replacement, generator=generator
+    )
+    output = output_.reshape(*list(input.shape[:-1]), -1)
+    return output
+
+
+def sample_top_k(probs: Tensor, k: int) -> Tensor:
+    top_k_value, _ = torch.topk(probs, k, dim=-1)
+    min_value_top_k = top_k_value[..., [-1]]
+    probs *= (probs >= min_value_top_k).float()
+    probs.div_(probs.sum(dim=-1, keepdim=True))
+    next_token = multinomial(probs, num_samples=1)
+    return next_token
+
+
+def sample_top_p(probs: Tensor, p: float) -> Tensor:
+    probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    mask = probs_sum - probs_sort > p
+    probs_sort *= (~mask).float()
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+    next_token = multinomial(probs_sort, num_samples=1)
+    next_token = torch.gather(probs_idx, -1, next_token)
+
+    return next_token
+
+
+def sample_top_p_top_k(probs: Tensor, p: float, top_k: int):
+    probs_sort, probs_idx = torch.sort(probs, dim=-1, descending=True)
+    probs_sum = torch.cumsum(probs_sort, dim=-1)
+    mask = probs_sum - probs_sort > p
+    probs_sort *= (~mask).float()
+    probs_sort.div_(probs_sort.sum(dim=-1, keepdim=True))
+    next_token = sample_top_k(probs_sort, top_k)
+    next_token = torch.gather(probs_idx, -1, next_token)
+    return next_token

--- a/src/vui/mlx/engine.py
+++ b/src/vui/mlx/engine.py
@@ -1,0 +1,329 @@
+"""Engine-API-compatible MLX backend (Apple Silicon).
+
+`vui.engine.Engine()` dispatches here automatically when CUDA is unavailable,
+so the README Python API works unchanged on M-series:
+
+    from vui.engine import Engine, GenConfig
+    engine = Engine()
+    with engine.new_row() as row:
+        codes, audio = row.render("Hello there!", GenConfig(temperature=0.7))
+
+Single-row only: the Row surface (prefill / add_user / stream / render /
+rewind / reset) matches the CUDA engine; continuous batching (max_rows > 1),
+two-speaker prefill, and the entropy/probe gates stay CUDA-only. Repetition
+penalty state is per-chunk here rather than per-render-call.
+"""
+
+import os
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+from vui.inference import chunk_text
+from vui.mlx.tts.generate import CODEC_HZ, compute_cond_bias
+from vui.mlx.tts.stream import TTSStream
+from vui.mlx.tts.weights import load_quantized
+
+
+def load_official_prompt(
+    voice: str, prompt_dir: str | None = None
+) -> tuple[str, mx.array, mx.array, mx.array | None]:
+    """Returns (transcript, codes (T,Q) int32, spk_token (1,1,d), cond_bias|None).
+
+    `prompt_dir` reads local <voice>.safetensors/.txt; default downloads the
+    pre-baked set from the HF repo (codes + pre-projected speaker token +
+    cond_bias, so no torch codec encoder is needed for the official voices).
+    """
+    if prompt_dir:
+        st = mx.load(f"{prompt_dir}/{voice}.safetensors")
+        txt_path = f"{prompt_dir}/{voice}.txt"
+    else:
+        from huggingface_hub import hf_hub_download
+
+        st = mx.load(hf_hub_download("fluxions/vui", f"prompts/{voice}.safetensors"))
+        txt_path = hf_hub_download("fluxions/vui", f"prompts/{voice}.txt")
+    with open(txt_path) as f:
+        text = f.read().strip()
+    codes = st["codes"].astype(mx.int32)  # (T, Q)
+    spk_token = st["spk_token_emb"].astype(mx.float32)  # (1, 1, d) pre-projected
+    cond_bias = st.get("cond_bias")
+    if cond_bias is not None:
+        cond_bias = cond_bias.astype(mx.float32)
+    return text, codes, spk_token, cond_bias
+
+
+def _to_mx_codes(codes) -> mx.array:
+    """(T, Q) torch long / numpy / mx -> mx int32."""
+    if isinstance(codes, mx.array):
+        return codes.astype(mx.int32)
+    if isinstance(codes, torch.Tensor):
+        codes = codes.detach().cpu().numpy()
+    return mx.array(np.asarray(codes).astype(np.int32))
+
+
+def _audio_to_torch(audio_mx: mx.array) -> torch.Tensor:
+    """(S,) mx float -> (1, 1, S) torch float32."""
+    return torch.from_numpy(np.array(audio_mx)).float().reshape(1, 1, -1)
+
+
+class MLXRow:
+    """Single conversation slot on the MLX engine. Mirrors vui.engine.Row."""
+
+    def __init__(self, engine: "MLXEngine"):
+        self._engine = engine
+        self._prompt_offset = 0
+        self._prompt_codes: mx.array | None = None  # for codec re-warm on rewind
+        self._spk_token: mx.array | None = None
+        self._closed = False
+        self.prompt_wps: float = 0.0
+
+    @property
+    def idx(self) -> int:
+        return 0
+
+    @property
+    def offset(self) -> int:
+        return self._engine.model.decoder.cache_T
+
+    def prefill(self, segments, spk_emb=None, segments_2=None, spk_emb_2=None) -> int:
+        if segments_2 is not None or spk_emb_2 is not None:
+            raise NotImplementedError("two-speaker prefill is CUDA-only")
+        return self._engine._prefill_row(self, segments, spk_emb)
+
+    def add_user(self, text: str = "", codes=None, *, final: bool = True) -> int:
+        return self._engine._add_user(self, text, codes, final=final)
+
+    def stream(self, text, cfg=None, cancel=None, *, reset_rep=True, final_turn=False):
+        """Yield (1, 1, 1920) float32 audio tensors per frame (CPU)."""
+        from vui.engine import GenConfig
+
+        cfg = cfg or GenConfig()
+        for _codes, audio in self._engine._stream_row(self, text, cfg, cancel):
+            yield _audio_to_torch(audio)
+        if final_turn:
+            self._engine._append_sc()
+
+    def render(self, text, cfg=None) -> tuple[torch.Tensor, torch.Tensor]:
+        """Generate a full turn. Returns (codes (T, Q) long, audio (1, 1, S))."""
+        from vui.engine import GenConfig
+
+        cfg = cfg or GenConfig()
+        all_codes, all_audio = [], []
+        for codes, audio in self._engine._stream_row(self, text, cfg, None):
+            all_codes.append(torch.from_numpy(np.array(codes)).long())
+            all_audio.append(np.array(audio))
+        if not all_codes:
+            return torch.zeros(0, self._engine.Q, dtype=torch.long), torch.zeros(1, 1, 0)
+        codes_t = torch.stack(all_codes)
+        audio_t = torch.from_numpy(np.concatenate(all_audio)).float().reshape(1, 1, -1)
+        return codes_t, audio_t
+
+    def rewind(self) -> int:
+        """Rewind KV to end-of-prompt."""
+        return self._engine._rewind_row(self, self._prompt_offset)
+
+    def reset(self) -> int:
+        """Rewind KV to 0."""
+        self._prompt_codes = None
+        return self._engine._rewind_row(self, 0)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._engine._row = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+class MLXEngine:
+    """Engine-API adapter over TTSStream. One row; no CUDA anywhere."""
+
+    def __init__(
+        self,
+        name: str = "vui-190k",
+        *,
+        model=None,
+        codec=None,
+        max_rows: int = 1,
+        max_seq: int | None = None,
+        codec_dtype=None,
+        vocoder_ctx: int = 25,
+        precision: str | None = None,
+    ):
+        if max_rows != 1:
+            raise NotImplementedError(
+                "MLX Engine supports max_rows=1; continuous batching is CUDA-only"
+            )
+        if model is not None or codec is not None:
+            raise TypeError(
+                "MLX Engine loads its own MLX model/codec — the model=/codec= "
+                "overrides take torch modules and are CUDA-only"
+            )
+        from vui.engine import Engine as _CudaEngine
+
+        path = _CudaEngine.NAMES.get(name, name)
+        precision = precision or os.environ.get("VUI_MLX_PRECISION", "int8")
+        print(f"[Engine-MLX] Loading model {path} ({precision}) ...")
+        self.model, self.config = load_quantized(path, precision)
+        from vui.mlx.tts.codec import load_codec_decoder_mlx
+
+        print("[Engine-MLX] Loading MLX codec decoder ...")
+        self.codec = load_codec_decoder_mlx()
+        self.model.rq_transformer.compile_forward()
+
+        self.max_rows = 1
+        self.tok = self.model.text_tokenizer
+        self.Q = self.model.rq_transformer.n_quantizers
+        self.CS = self.model.rq_transformer.codebook_size
+        self.D = self.model.d_model
+        self._ctx = TTSStream(self.model, self.codec, mx.zeros((1, 1, self.D)))
+        self._row: MLXRow | None = None
+
+    # -- conditioning -------------------------------------------------------
+
+    @property
+    def cond_bias(self) -> mx.array:
+        return self._ctx.cond_bias
+
+    @cond_bias.setter
+    def cond_bias(self, bias: mx.array) -> None:
+        self._ctx.cond_bias = bias
+
+    def set_conditioning(self, *, sq_scores=None, wps_score: float = 0.0) -> None:
+        self._ctx.cond_bias = compute_cond_bias(
+            self.model, sq=list(sq_scores) if sq_scores is not None else None,
+            wps=wps_score,
+        )
+
+    # -- rows ---------------------------------------------------------------
+
+    def new_row(self) -> MLXRow:
+        if self._row is not None and not self._row._closed:
+            raise RuntimeError("MLX Engine supports one open row at a time")
+        self._ctx.reset()
+        self._ctx._ensure_cache()
+        row = MLXRow(self)
+        self._row = row
+        return row
+
+    def reset(self) -> None:
+        if self._row is not None:
+            self._row.close()
+        self._ctx.reset()
+
+    # -- internals ----------------------------------------------------------
+
+    def _append_sc(self) -> None:
+        sc = self.model.token_emb(mx.array([[self.model.sc_id]]))
+        self.model.decoder(sc)
+        mx.eval([c.state for c in self.model.decoder.kv_caches])
+
+    def _prefill_row(self, row: MLXRow, segments, spk_emb) -> int:
+        """[spk] text_i codes_i per segment, [SC] on the last text — matches
+        the CUDA engine's _prefill_speaker_segments(final=True)."""
+        ctx = self._ctx
+        ctx._ensure_cache()
+
+        spk_token = None
+        if spk_emb is not None:
+            emb = spk_emb if isinstance(spk_emb, mx.array) else mx.array(
+                spk_emb.detach().float().cpu().numpy()
+            )
+            if emb.ndim == 3 and emb.shape[-1] == self.D:
+                spk_token = emb  # pre-projected token (official prompts)
+            elif self.model.spk_proj is not None:
+                spk_token = self.model.spk_proj(emb).reshape(1, 1, -1)
+        row._spk_token = spk_token
+        ctx._spk_token = spk_token  # re-injected before each generated chunk
+
+        all_codes = []
+        last = len(segments) - 1
+        for i, seg in enumerate(segments):
+            if spk_token is not None:
+                self.model.decoder(spk_token)
+            if seg.text:
+                ctx.add_text(seg.text, sc=(i == last))
+            if seg.codes is not None:
+                codes_mx = _to_mx_codes(seg.codes)
+                self.model.decoder(self.model.audio_emb(codes_mx)[None])
+                all_codes.append(codes_mx)
+        mx.eval([c.state for c in self.model.decoder.kv_caches])
+
+        if all_codes:
+            row._prompt_codes = mx.concatenate(all_codes, axis=0)
+            self._warm_codec(row._prompt_codes)
+
+        row._prompt_offset = self.model.decoder.cache_T
+
+        total_words = sum(len(s.text.split()) for s in segments if s.text)
+        total_frames = sum(s.codes.shape[0] for s in segments if s.codes is not None)
+        if total_frames > 0 and total_words > 0:
+            row.prompt_wps = total_words / (total_frames / CODEC_HZ)
+        return row._prompt_offset
+
+    def _warm_codec(self, codes_mx: mx.array) -> None:
+        self.codec.reset_state()
+        self.codec.prefill(codes_mx.T[None])
+        mx.eval(self.codec.parameters())
+        self._ctx._codec_ready = True
+
+    def _add_user(self, row: MLXRow, text: str, codes, *, final: bool = True) -> int:
+        """text [SC] codes — same layout as the CUDA engine's _add_user."""
+        ctx = self._ctx
+        ctx._ensure_cache()
+        if text:
+            ctx.add_text(text, sc=final)
+        elif final:
+            self._append_sc()
+        if codes is not None:
+            codes_mx = _to_mx_codes(codes)
+            self.model.decoder(self.model.audio_emb(codes_mx)[None])
+            self._warm_codec(codes_mx)
+        mx.eval([c.state for c in self.model.decoder.kv_caches])
+        return self.model.decoder.cache_T
+
+    def _rewind_row(self, row: MLXRow, offset: int) -> int:
+        for c in self.model.decoder.kv_caches:
+            c.offset = min(c.offset, offset)
+        if offset > 0 and row._prompt_codes is not None:
+            self._warm_codec(row._prompt_codes)
+        else:
+            self.codec.reset_state()
+            self._ctx._codec_ready = False
+        return offset
+
+    def _stream_row(self, row: MLXRow, text: str, cfg, cancel):
+        """Chunk the text like the CUDA engine and yield (codes, audio) frames."""
+        chunks = chunk_text(
+            text, min_words=cfg.chunk_words, sentence_only=cfg.sentence_only,
+            single_speaker=True,
+        )
+        min_frames = max(1, int(cfg.min_secs * CODEC_HZ))
+        max_total = int(cfg.max_secs * CODEC_HZ)
+        total = 0
+        for ch in chunks:
+            n_words = len(ch["text"].split())
+            max_frames = min(cfg.max_turn_frames(n_words, row.prompt_wps),
+                             max_total - total)
+            if max_frames <= 0:
+                break
+            for codes, audio in self._ctx.generate(
+                ch["text"],
+                temperature=cfg.temperature,
+                top_k=cfg.top_k or 300,
+                max_frames=max_frames,
+                eos_threshold=cfg.eos_threshold,
+                min_frames=min_frames,
+                rep_penalty=cfg.rep_penalty,
+                rep_window=cfg.rep_window,
+                n_codebooks=cfg.n_codebooks,
+            ):
+                if cancel is not None and cancel.is_set():
+                    return
+                total += 1
+                yield codes, audio

--- a/src/vui/mlx/legacy.py
+++ b/src/vui/mlx/legacy.py
@@ -1,0 +1,171 @@
+"""MLX backend for the original-release (pre-1.0) 100M checkpoints.
+
+Hybrid split: the 12-layer decoder (virtually all the compute in the
+autoregressive loop) runs on MLX; embeddings, audio heads, the delayed
+codebook pattern, sampling, and the Fluac codec stay in the proven torch
+code from vui.legacy — those are per-step lookups and a 9x1008x768 matmul,
+too small to matter. `MLXDecoderAdapter` plugs into vui.legacy.generate /
+render via their `decoder=` override.
+
+    from vui.mlx.legacy import load_legacy_mlx
+    model, adapter = load_legacy_mlx("vui-cohost-100m.pt")
+    audio = render(model, "Hello!", decoder=adapter)
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import torch
+
+from vui.mlx.tts.model import KVCache
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    """GPT-J interleaved: pairs (x0,x1) -> (-x1,x0)."""
+    shape = x.shape
+    x = x.reshape(*shape[:-1], shape[-1] // 2, 2)
+    x1 = x[..., 0]
+    x2 = x[..., 1]
+    return mx.stack([-x2, x1], axis=-1).reshape(shape)
+
+
+class _LegacyMHA(nn.Module):
+    def __init__(self, d_model: int, n_heads: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.scale = self.head_dim**-0.5
+        self.Wqkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+
+    def __call__(self, x, cos, sin, cache):
+        B, T, _ = x.shape
+        qkv = self.Wqkv(x)
+        q, k, v = mx.split(qkv, 3, axis=-1)
+        q = q.reshape(B, T, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = k.reshape(B, T, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = v.reshape(B, T, self.n_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        # cos/sin: (T, head_dim) for these positions, broadcast over B, heads
+        q = q * cos + _rotate_half(q) * sin
+        k = k * cos + _rotate_half(k) * sin
+
+        k, v = cache.update_and_fetch(k, v)
+
+        if T > 1:
+            mask = nn.MultiHeadAttention.create_additive_causal_mask(k.shape[2])
+            mask = mask[-T:]
+        else:
+            mask = None
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+        return self.out_proj(out.transpose(0, 2, 1, 3).reshape(B, T, -1))
+
+
+class _LegacyMLP(nn.Module):
+    def __init__(self, d_model: int, hidden: int):
+        super().__init__()
+        self.w1 = nn.Linear(d_model, hidden, bias=False)
+        self.w3 = nn.Linear(d_model, hidden, bias=False)
+        self.w2 = nn.Linear(hidden, d_model, bias=False)
+
+    def __call__(self, x):
+        return self.w2(nn.silu(self.w1(x)) * self.w3(x))
+
+
+class _LegacyBlock(nn.Module):
+    def __init__(self, d_model: int, n_heads: int, hidden: int):
+        super().__init__()
+        self.attn_norm = nn.RMSNorm(d_model, eps=1e-5)
+        self.attn = _LegacyMHA(d_model, n_heads)
+        self.mlp_norm = nn.RMSNorm(d_model, eps=1e-5)
+        self.mlp = _LegacyMLP(d_model, hidden)
+
+    def __call__(self, x, cos, sin, cache):
+        x = x + self.attn(self.attn_norm(x), cos, sin, cache)
+        return x + self.mlp(self.mlp_norm(x))
+
+
+class LegacyDecoderMLX(nn.Module):
+    def __init__(self, n_layers: int, d_model: int, n_heads: int, hidden: int):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.blocks = [_LegacyBlock(d_model, n_heads, hidden) for _ in range(n_layers)]
+        self.norm = nn.RMSNorm(d_model, eps=1e-5)
+        self.kv_caches: list[KVCache] = []
+        self.max_seqlen = 0
+        self._cos: mx.array | None = None
+        self._sin: mx.array | None = None
+
+    def make_cache(self):
+        self.kv_caches = [
+            KVCache(self.n_heads, self.head_dim, self.max_seqlen)
+            for _ in self.blocks
+        ]
+
+    def __call__(self, x):
+        offset = self.kv_caches[0].offset
+        T = x.shape[1]
+        cos = self._cos[offset : offset + T]
+        sin = self._sin[offset : offset + T]
+        for block, cache in zip(self.blocks, self.kv_caches):
+            x = block(x, cos, sin, cache)
+        return self.norm(x)
+
+
+class MLXDecoderAdapter:
+    """Drop-in for the legacy torch Decoder in vui.legacy.generate(decoder=...).
+
+    Takes/returns torch tensors; positions are tracked by the KV cache offset,
+    so `input_pos` is validated against it rather than used."""
+
+    def __init__(self, torch_decoder):
+        cfg_blocks = torch_decoder.blocks
+        d_model = cfg_blocks[0].attn.dim
+        n_heads = cfg_blocks[0].n_heads
+        hidden = cfg_blocks[0].mlp.w1.out_features
+        dec = LegacyDecoderMLX(len(cfg_blocks), d_model, n_heads, hidden)
+        dec.max_seqlen = torch_decoder.max_seqlen
+
+        # Identical RoPE values: reuse the torch-precomputed freqs buffer
+        freqs = torch_decoder.freqs_cis.detach().float().cpu().numpy()
+        dec._cos = mx.array(np.cos(freqs))
+        dec._sin = mx.array(np.sin(freqs))
+
+        sd = {k: v.detach().float().cpu().numpy()
+              for k, v in torch_decoder.state_dict().items()}
+        for i, block in enumerate(dec.blocks):
+            p = f"blocks.{i}"
+            block.attn_norm.weight = mx.array(sd[f"{p}.attn_norm.weight"])
+            block.attn.Wqkv.weight = mx.array(sd[f"{p}.attn.Wqkv.weight"])
+            block.attn.out_proj.weight = mx.array(sd[f"{p}.attn.out_proj.weight"])
+            block.mlp_norm.weight = mx.array(sd[f"{p}.mlp_norm.weight"])
+            block.mlp.w1.weight = mx.array(sd[f"{p}.mlp.w1.weight"])
+            block.mlp.w3.weight = mx.array(sd[f"{p}.mlp.w3.weight"])
+            block.mlp.w2.weight = mx.array(sd[f"{p}.mlp.w2.weight"])
+        dec.norm.weight = mx.array(sd["norm.weight"])
+        mx.eval(dec.parameters())
+        self.decoder = dec
+
+    def allocate_inference_cache(self, batch_size: int, device, dtype=None):
+        assert batch_size == 1, "MLX legacy decoder is B=1"
+        self.decoder.make_cache()
+
+    def __call__(self, embeddings: torch.Tensor, input_pos: torch.Tensor):
+        offset = self.decoder.kv_caches[0].offset
+        assert int(input_pos[0]) == offset, (
+            f"non-sequential input_pos {int(input_pos[0])} != cache offset {offset}"
+        )
+        x = mx.array(embeddings.detach().float().cpu().numpy())
+        out = self.decoder(x)
+        mx.eval(out)
+        return torch.from_numpy(np.array(out))
+
+
+def load_legacy_mlx(checkpoint_path: str = "vui-cohost-100m.pt"):
+    """Returns (torch legacy Vui on CPU, MLXDecoderAdapter). Render with
+    vui.legacy.render(model, text, decoder=adapter)."""
+    from vui.legacy import Vui
+
+    model = Vui.from_pretrained(checkpoint_path).eval()
+    return model, MLXDecoderAdapter(model.decoder)

--- a/src/vui/mlx/tts/stream.py
+++ b/src/vui/mlx/tts/stream.py
@@ -1,0 +1,165 @@
+"""Simple streaming TTS interface for MLX.
+
+Usage:
+    ctx = TTSStream(model, codec, cond_bias)
+    ctx.add_speaker(spk_emb)
+    ctx.add_text(prompt_text, sc=True)
+    ctx.add_audio(prompt_codes)
+    for codes, audio in ctx.generate(text):
+        # codes: (Q,) per frame, audio: (1920,) float32
+        play(audio)
+    ctx.reset()
+"""
+
+import mlx.core as mx
+import numpy as np
+
+from vui.inference import simple_clean
+from vui.mlx.tts.generate import RepPenalty
+from vui.mlx.tts.model import VuiMLX
+
+
+def _sample_top_k(logits: mx.array, top_k: int, temperature: float) -> mx.array:
+    logits = logits / temperature
+    top_vals = mx.topk(logits, top_k, axis=-1)
+    logits = mx.where(logits < top_vals[:, -1:], mx.array(-1e9), logits)
+    return mx.random.categorical(logits)
+
+
+class TTSStream:
+    def __init__(self, model: VuiMLX, codec=None, cond_bias: mx.array | None = None):
+        self.model = model
+        self.codec = codec
+        self.cond_bias = (
+            cond_bias if cond_bias is not None else mx.zeros((1, 1, model.d_model))
+        )
+        self._codec_ready = False
+        self._spk_token: mx.array | None = None
+
+    def reset(self):
+        self.model.decoder.reset_cache()
+        if self.codec is not None:
+            self.codec.reset_state()
+        self._codec_ready = False
+        self._spk_token = None
+
+    def add_speaker(self, spk_emb: mx.array):
+        self._ensure_cache()
+        self._spk_token = self.model.spk_proj(spk_emb).reshape(1, 1, -1)
+        self.model.decoder(self._spk_token)
+
+    def add_text(self, text: str, sc: bool = False):
+        self._ensure_cache()
+        ids = self.model.text_tokenizer.encode(simple_clean(text))
+        ids_mx = mx.array(np.array(ids, dtype=np.int32))
+        if sc:
+            ids_mx = mx.concatenate([ids_mx, mx.array([self.model.sc_id])])
+        emb = self.model.token_emb(ids_mx[None])
+        self.model.decoder(emb)
+
+    def add_audio(self, codes: mx.array):
+        self._ensure_cache()
+        # codes: (1, Q, T) or (T, Q)
+        if codes.ndim == 3:
+            pc = codes[0].T  # (T, Q)
+        else:
+            pc = codes
+        emb = self.model.audio_emb(pc)[None]  # (1, T, d)
+        self.model.decoder(emb)
+        # Warm codec conv state with these codes
+        if self.codec is not None:
+            codec_codes = codes if codes.ndim == 3 else codes.T[None]
+            self.codec.reset_state()
+            self.codec.prefill(codec_codes)
+            mx.eval(self.codec.parameters())
+            self._codec_ready = True
+
+    def generate(
+        self,
+        text: str,
+        temperature: float = 0.8,
+        top_k: int = 300,
+        max_frames: int = 187,
+        eos_threshold: float = 0.45,
+        min_frames: int = 6,
+        rep_penalty: float = 1.4,
+        rep_window: int = 24,
+        n_codebooks: int = 0,
+    ):
+        """Yield (codes, audio) per frame. audio is None if no codec.
+
+        n_codebooks > 0 truncates generation to that many quantizers
+        (rq max_q); 0 uses all of them."""
+        self._ensure_cache()
+        m = self.model
+        Q = m.rq_transformer.n_quantizers
+        CS = m.rq_transformer.codebook_size
+        eff_q = n_codebooks if 0 < n_codebooks < Q else Q
+        rq_temp = temperature
+        rep = RepPenalty(eff_q, CS, rep_penalty, rep_window)
+
+        # Re-inject speaker token before each new turn (matches training format)
+        if self._spk_token is not None:
+            m.decoder(self._spk_token)
+
+        # Text prefill with cond_bias
+        ids = m.text_tokenizer.encode(simple_clean(text))
+        ids_mx = mx.array(ids.numpy().astype(np.int32))
+        text_emb = m.token_emb(ids_mx[None]) + self.cond_bias
+        out = m.decoder(text_emb)
+
+        # First frame from last text hidden
+        hidden = out[:, -1:]
+        code0 = _sample_top_k(m.codec_head(hidden[:, 0]), top_k, temperature)
+        codes = m.rq_transformer.generate(
+            hidden[:, 0], code0, rq_temp, top_k, max_q=eff_q
+        )
+        codes_in = codes[0]
+        mx.eval(codes_in)
+        rep.update(codes_in)
+
+        audio = self._decode_frame(codes_in) if self.codec is not None else None
+        yield codes_in, audio
+
+        for step in range(1, max_frames):
+            emb = m.audio_emb(codes_in[None])[None]
+            h = m.decoder(emb)
+            hidden = h[:, 0]
+
+            eos_logit = m.eos_head(hidden)
+            cb0_logits = rep.apply_cb0(m.codec_head(hidden))
+            code0 = _sample_top_k(cb0_logits, top_k, temperature)
+            logit_bias = rep.rq_logit_bias()
+            codes = m.rq_transformer.generate(
+                hidden, code0, rq_temp, top_k, logit_bias, max_q=eff_q
+            )
+
+            mx.eval(codes, eos_logit)
+
+            if (
+                step >= min_frames
+                and float(mx.sigmoid(eos_logit).item()) > eos_threshold
+            ):
+                break
+
+            codes_in = codes[0]
+            rep.update(codes_in)
+            audio = self._decode_frame(codes_in) if self.codec is not None else None
+            yield codes_in, audio
+
+    def _decode_frame(self, codes: mx.array) -> mx.array:
+        # codes: (Q,) -> (1, Q, 1) for codec
+        frame = codes[None, :, None]
+        if not self._codec_ready:
+            self.codec.reset_state()
+            self.codec.prefill(frame)
+            mx.eval(self.codec.parameters())
+            self._codec_ready = True
+            return mx.zeros((1920,))
+        audio = self.codec.decode_frame(frame)
+        mx.eval(audio)
+        return audio.flatten()
+
+    def _ensure_cache(self):
+        if not self.model.decoder.kv_caches:
+            self.model.decoder.make_cache()

--- a/src/vui/model.py
+++ b/src/vui/model.py
@@ -23,9 +23,10 @@ def reject_legacy_checkpoint(state_dict: dict, source: str = "checkpoint"):
         raise ValueError(
             f"{source} is a legacy checkpoint from the original vui release "
             "(per-quantizer audio_embeddings/audio_heads, no rq_transformer) "
-            "and does not match the current architecture. Use "
-            "'vui-190k.safetensors' (default) or 'vui-nano.safetensors' from "
-            "https://huggingface.co/fluxions/vui instead."
+            "and does not match the current architecture. Load it with "
+            "vui.legacy instead (`from vui.legacy import Vui, render`), or "
+            "use a current checkpoint: 'vui-190k.safetensors' (default) or "
+            "'vui-nano.safetensors' from https://huggingface.co/fluxions/vui."
         )
 
 


### PR DESCRIPTION
Follow-up to #28 / #27: the Engine API now works on Apple Silicon, and the original-release 100M checkpoints run again.

## MLX Engine (`vui.mlx.engine`)
`Engine()` auto-dispatches to a single-row MLX backend when CUDA is unavailable — the README example runs unchanged on M-series. Same Row API (`prefill` / `add_user` / `render` / `stream` / `rewind` / `reset`), backed by `TTSStream` (ported from the internal tree). Official voices load via `load_official_prompt` from the pre-baked HF safetensors (codes + pre-projected speaker token + cond_bias) — no torch codec encoder needed. Continuous batching (`max_rows > 1`), two-speaker prefill, and the entropy/probe gates stay CUDA-only and raise clear errors.

Verified on M4 (int8 vui-190k, all renders whisper-transcribed word-perfect): README + docs code blocks exec'd verbatim, prompted render 1.2–2.7× RTF, per-frame `stream()`, rewind + re-render, add_user turns, cancel, row-lifecycle guards. Also verified from a fresh non-editable install with empty caches (pre-baked weights auto-download: 696 MB TTS + 456 MB codec).

## CLI consolidation
`demo.py --render` on Apple Silicon now goes through the Engine API instead of wrapping the streaming worker — one MLX generation loop for CLI and Python API. `--n-codebooks` is wired through `TTSStream` (rq `max_q`).

## Legacy checkpoints (`vui.legacy`, `vui.mlx.legacy`)
The pre-1.0 architecture (per-quantizer audio embeddings/heads, delayed codebook pattern, Fluac 22 kHz codec) is resurrected from the initial commit, so `vui-100m-base.pt` / `vui-cohost-100m.pt` / `vui-abraham-100m.pt` load with zero dropped keys and render:

- **CPU**: 1.3× real-time, no flash-attn. **MPS refused** (corrupted output, slower than CPU).
- **Apple Silicon MLX**: `load_legacy_mlx` runs the transformer on MLX at ~4.5× real-time (TTFB ~115 ms); embeddings/heads/sampling/codec stay on torch-CPU. Decoder parity vs torch: max 3.5e-4 (fp32), `allclose(atol=1e-4)`.

The legacy-checkpoint loader error now points at `vui.legacy` instead of just naming the new checkpoints.

## Docs
New `docs/legacy.md`; `docs/python-api.md` MLX section rewritten for the Engine API; README Apple Silicon status refreshed.