### PR TITLE
mlx: fix top-k sampling collapsing to greedy decoding

### DIFF
--- a/src/vui/mlx/tts/generate.py
+++ b/src/vui/mlx/tts/generate.py
@@ -14,9 +14,10 @@ CODEC_HZ = 12.5
 
 def _sample_top_k(logits: mx.array, top_k: int) -> mx.array:
     top_vals = mx.topk(logits, top_k, axis=-1)
-    return mx.random.categorical(
-        mx.where(logits < top_vals[:, -1:], mx.array(-1e9), logits)
-    )
+    # mx.topk gives no order guarantee (it's argpartition-backed and happens to
+    # come back ascending), so take the k-th largest as an explicit min.
+    thresh = mx.min(top_vals, axis=-1, keepdims=True)
+    return mx.random.categorical(mx.where(logits < thresh, mx.array(-1e9), logits))
 
 
 class RepPenalty:

--- a/src/vui/mlx/tts/model.py
+++ b/src/vui/mlx/tts/model.py
@@ -333,7 +333,8 @@ class RQTransformer(nn.Module):
         logits_0 = logits_0 / temperature
         if top_k is not None:
             top_vals = mx.topk(logits_0, top_k, axis=-1)
-            logits_0 = mx.where(logits_0 < top_vals[:, -1:], mx.array(-1e9), logits_0)
+            thresh = mx.min(top_vals, axis=-1, keepdims=True)
+            logits_0 = mx.where(logits_0 < thresh, mx.array(-1e9), logits_0)
         next_code = mx.random.categorical(logits_0)
         codes = [code_0, next_code]
 
@@ -349,9 +350,8 @@ class RQTransformer(nn.Module):
             logits_i = logits_i / temperature
             if top_k is not None:
                 top_vals = mx.topk(logits_i, top_k, axis=-1)
-                logits_i = mx.where(
-                    logits_i < top_vals[:, -1:], mx.array(-1e9), logits_i
-                )
+                thresh = mx.min(top_vals, axis=-1, keepdims=True)
+                logits_i = mx.where(logits_i < thresh, mx.array(-1e9), logits_i)
             next_code = mx.random.categorical(logits_i)
             codes.append(next_code)
 


### PR DESCRIPTION
MLX `mx.topk` returns its k values in **ascending** order (unlike torch, which is descending). The sampling paths took the threshold as `top_vals[:, -1:]` — the *largest* logit, not the k-th largest — so the mask zeroed everything except the argmax. Top-k sampling collapsed to greedy decoding regardless of `top_k`/`temperature`.

Fixed in three places:
- `src/vui/mlx/tts/generate.py` (`_sample_top_k`)
- `src/vui/mlx/tts/model.py` (`RQTransformer.generate`, both codebook branches)

Uses `mx.min(top_vals, axis=-1, keepdims=True)` rather than `top_vals[:, :1]`, since MLX does not document `topk` as sorted — the ascending order falls out of the underlying argpartition.

Verified on an Apple machine with mlx installed:

```
topk     : [[0.730221, 0.884373, 2.00178], [0.579773, 0.667879, 0.833127]]
old thr  : [[2.00178],  [0.833127]]     old kept per row: [1, 1]   <- greedy
new thr  : [[0.730221], [0.579773]]     new kept per row: [3, 3]   <- k=3
```