### PR TITLE
mlx: fix top-k greedy collapse in the streaming sampler

### DIFF
--- a/src/vui/mlx/tts/stream.py
+++ b/src/vui/mlx/tts/stream.py
@@ -22,7 +22,10 @@ from vui.mlx.tts.model import VuiMLX
 def _sample_top_k(logits: mx.array, top_k: int, temperature: float) -> mx.array:
     logits = logits / temperature
     top_vals = mx.topk(logits, top_k, axis=-1)
-    logits = mx.where(logits < top_vals[:, -1:], mx.array(-1e9), logits)
+    # mx.topk gives no order guarantee (it's argpartition-backed and happens to
+    # come back ascending), so take the k-th largest as an explicit min.
+    thresh = mx.min(top_vals, axis=-1, keepdims=True)
+    logits = mx.where(logits < thresh, mx.array(-1e9), logits)
     return mx.random.categorical(logits)
 
 


### PR DESCRIPTION
Follow-up to #31. `src/vui/mlx/tts/stream.py` landed in #30 in parallel and carried the same `top_vals[:, -1:]` bug — `mx.topk` returns ascending, so the threshold was the largest logit and the mask left only the argmax, collapsing streaming top-k sampling to greedy.

Same order-independent `mx.min(top_vals, axis=-1, keepdims=True)` fix.